### PR TITLE
Update version of pygit2 to 1.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ progress
 PyYAML
 lastversion
 coloredlogs
-pygit2
+pygit2==1.6.1
 python3-wget
 beautifulsoup4


### PR DESCRIPTION
## Description
Update version of pygit2 to v1.6.1
The latest version, 1.7.0, has an error and cannot be installed.
- Related Issue : https://github.com/libgit2/pygit2/issues/1097

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

