### PR TITLE
Fix bug in opossum exporter

### DIFF
--- a/src/fosslight_util/write_opossum.py
+++ b/src/fosslight_util/write_opossum.py
@@ -11,6 +11,8 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import traceback
+from typing import Dict
+
 import fosslight_util.constant as constant
 from fosslight_util.write_excel import remove_empty_sheet
 
@@ -237,7 +239,7 @@ def make_resources(path, resources):
 def make_resources_and_attributions(sheet_items, scanner, resources, fc_list):
     success = True
     resourcesToAttributions = {}
-    externalAttributions = {}
+    externalAttributions: Dict[str, Attribution] = {}
     externalAttribution_list = []
     ab_list = []
 
@@ -269,7 +271,7 @@ def make_resources_and_attributions(sheet_items, scanner, resources, fc_list):
 
             find_same_attribution = False
             uuid = ''
-            for externalAttribution in externalAttributions:
+            for externalAttribution in externalAttributions.values():
                 if attribution == externalAttribution:
                     find_same_attribution = True
                     uuid = externalAttribution.uuid
@@ -285,11 +287,14 @@ def make_resources_and_attributions(sheet_items, scanner, resources, fc_list):
             resourcesToAttributions[os.path.join(os.sep, path)] = uuid_list
 
             for ext in externalAttribution_list:
-                dict = ext.get_externalAttribution_dict()
-                externalAttributions[str(ext.uuid)] = dict
+                externalAttributions[str(ext.uuid)] = ext
     except Exception as e:
         logger.error("Failed to make_resources_and_attributions: " + str(e))
         logger.error(traceback.format_exc())
         success = False
 
-    return success, resources, externalAttributions, resourcesToAttributions, fc_list, ab_list
+    externalAttributionsConverted = {
+        uuid: ext.get_externalAttribution_dict() for uuid, ext in externalAttributions.items()
+    }
+
+    return success, resources, externalAttributionsConverted, resourcesToAttributions, fc_list, ab_list


### PR DESCRIPTION
## Description
While looking at the function for exporting files for Opossum I identified a bug:

When checking if an external attribution already was created the comparison never returned `True` as a dictionary was compared with an instance of Attribution.
In order to resolve this conversion to the dict (which is ultimately written in the json file) is done at a later stage. Furthermore, a type annotation was added.


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

