### PR TITLE
Exclude null fields from opossum export

### DIFF
--- a/src/fosslight_util/write_opossum.py
+++ b/src/fosslight_util/write_opossum.py
@@ -11,7 +11,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import traceback
-from typing import Dict
+from typing import Dict, Optional
 
 import fosslight_util.constant as constant
 from fosslight_util.write_excel import remove_empty_sheet
@@ -37,8 +37,15 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 
 
 class AttributionItem():
-    def __init__(self, source_name, licenseName, exclude,
-                 copyright='', packageName='', packageVersion='', url='', packageType=''):
+    def __init__(self,
+                 source_name: str,
+                 licenseName: str,
+                 exclude: bool,
+                 copyright: Optional[str] = None,
+                 packageName: Optional[str] = None,
+                 packageVersion: Optional[str] = None,
+                 url: Optional[str] = None,
+                 packageType: Optional[str] = None):
         self.attributionConfidence = _attributionConfidence
         self.documentConfidence = _attributionConfidence
         if exclude:
@@ -61,8 +68,15 @@ class AttributionItem():
 
 
 class Attribution(AttributionItem):
-    def __init__(self, source_name, licenseName, exclude,
-                 copyright='', packageName='', packageVersion='', url='', packageType=''):
+    def __init__(self,
+                 source_name: str,
+                 licenseName: str,
+                 exclude: bool,
+                 copyright: Optional[str] = None,
+                 packageName: Optional[str] = None,
+                 packageVersion: Optional[str] = None,
+                 url: Optional[str] = None,
+                 packageType: Optional[str] = None):
         super().__init__(source_name, licenseName, exclude, copyright=copyright,
                          packageName=packageName, packageVersion=packageVersion, url=url, packageType=packageType)
 
@@ -116,7 +130,7 @@ class Attribution(AttributionItem):
             dict[url] = self.url
             dict[packageType] = self.packageType
 
-        return dict
+        return {key: value for key, value in dict if value is not None}
 
 
 def make_metadata():

--- a/src/fosslight_util/write_opossum.py
+++ b/src/fosslight_util/write_opossum.py
@@ -130,7 +130,7 @@ class Attribution(AttributionItem):
             dict[url] = self.url
             dict[packageType] = self.packageType
 
-        return {key: value for key, value in dict if value is not None}
+        return {key: value for key, value in dict.items() if value is not None}
 
 
 def make_metadata():


### PR DESCRIPTION
## Description
Certain fields in the opossum file are optional and do not need to be written(see https://github.com/opossum-tool/OpossumUI/blob/main/src/ElectronBackend/input/OpossumInputFileSchema.json). Instead of writing an empty string just excluding the field from the json is preferred.
(sneaked in some more type annotations)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

