### PR TITLE
When outputting opossum format, cut as many columns as necessary.

### DIFF
--- a/src/fosslight_util/write_opossum.py
+++ b/src/fosslight_util/write_opossum.py
@@ -260,6 +260,7 @@ def make_resources_and_attributions(sheet_items, scanner, resources, fc_list):
 
     try:
         for items in sheet_items:
+            items = items[0:9]
             path, oss_name, oss_version, license, url, homepage, copyright, exclude, comment = items
 
             if scanner == FL_SOURCE:


### PR DESCRIPTION
## Description
Add function to slice column numbers when writing report in opossum format 
If there is an additional column to write, it is needed to prevent abnormal output.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

