### PR TITLE
Fix the opossum result to print the multiple resourcesToAttribution

### DIFF
--- a/src/fosslight_util/write_opossum.py
+++ b/src/fosslight_util/write_opossum.py
@@ -300,7 +300,10 @@ def make_resources_and_attributions(sheet_items, scanner, resources, fc_list):
 
             uuid_list = []
             uuid_list.append(str(uuid))
-            resourcesToAttributions[os.path.join(os.sep, path)] = uuid_list
+            if os.path.join(os.sep, path) in resourcesToAttributions:
+                resourcesToAttributions[os.path.join(os.sep, path)].extend(uuid_list)
+            else:
+                resourcesToAttributions[os.path.join(os.sep, path)] = uuid_list
 
             for ext in externalAttribution_list:
                 externalAttributions[str(ext.uuid)] = ext

--- a/tests/test_opossum.py
+++ b/tests/test_opossum.py
@@ -13,6 +13,10 @@ def main():
     sheet_list = {'SRC_FL_Source': [
                   ['test/lib/babel-polyfill.js', '', '', 'bsd-3-clause,facebook-patent-rights-2', '', '',
                    'Copyright (c) 2014, Facebook, Inc.', 'Exclude', ''],
+                  ['lib/babel-polyfill.js', '', '', 'bsd-3-clause', '', '',
+                   'Copyright (c) 2014, Facebook, Inc.', '', ''],
+                  ['lib/babel-polyfill.js', '', '', 'facebook-patent-rights-2', '', '',
+                   'Copyright (c) 2014, Facebook, Inc.', '', ''],
                   ['requirements.txt', '', '', 'MIT', 'https://pypi.org/project/future/0.18.2', '', '', '', ''],
                   ['bower.json', '', '', 'mit', '', '', '', '', ''],
                   ['LICENSE', '', '', 'mit', '', '', 'Copyright (c) 2016-2021, The Cytoscape Consortium', '', ''],


### PR DESCRIPTION
Signed-off-by: Jiyeong Seok <jiyeong.seok@lge.com>

## Description
Fix the opossum result to print the multiple resourcesToAttribution


## Type of change
Please insert 'x' one of the type of change.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

