### PR TITLE
Install pygit2 according to python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ progress
 PyYAML
 lastversion
 coloredlogs
-pygit2==1.6.1
 python3-wget
 beautifulsoup4
 jsonmerge

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ if __name__ == "__main__":
         install_requires=required,
         package_data={'fosslight_util': ['resources/frequentLicenselist.json', 'resources/licenses.json']},
         include_package_data=True,
+        extras_require={":python_version<'3.7'": ["pygit2==1.6.1"],
+                        ":python_version>'3.6'": ["pygit2"]},
         entry_points={
             "console_scripts": [
                 "fosslight_download = fosslight_util.download:main",

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}
-basepython= python3.6
 whitelist_externals = cat
                       ls
 setenv =


### PR DESCRIPTION
## Description
pygit2 works with python 3.6 only up to 1.6.1,
and later versions work with python 3.7 or higher.

## Type of change
Please insert 'x' one of the type of change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

