### PR TITLE
Fix formatting errors that occur when dir is input

### DIFF
--- a/src/fosslight_util/output_format.py
+++ b/src/fosslight_util/output_format.py
@@ -26,10 +26,12 @@ def check_output_format(output='', format=''):
 
     if success:
         if output != '':
-            output_path = os.path.dirname(output)
+            basename_extension = ''
+            if not os.path.isdir(output):
+                output_path = os.path.dirname(output)
 
-            basename = os.path.basename(output)
-            basename_file, basename_extension = os.path.splitext(basename)
+                basename = os.path.basename(output)
+                basename_file, basename_extension = os.path.splitext(basename)
             if basename_extension:
                 find_ext = False
                 for _format, _ext in SUPPORT_FORMAT.items():


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
If directory is input as output and the directory name contains `.`, a format error occurs.
    - ex. output : `"/home/path/test.dir"` and `test.dir` is directory name.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

