### PR TITLE
Initialize the variable of the OSS Item

### DIFF
--- a/src/fosslight_util/oss_item.py
+++ b/src/fosslight_util/oss_item.py
@@ -89,11 +89,14 @@ class OssItem:
 
     @source_name_or_path.setter
     def source_name_or_path(self, value):
-        if not isinstance(value, list):
-            value = value.split(",")
-        self._source_name_or_path.extend(value)
-        self._source_name_or_path = [item.strip() for item in self._source_name_or_path]
-        self._source_name_or_path = list(set(self._source_name_or_path))
+        if not value:
+            self._source_name_or_path = []
+        else:
+            if not isinstance(value, list):
+                value = value.split(",")
+            self._source_name_or_path.extend(value)
+            self._source_name_or_path = [item.strip() for item in self._source_name_or_path]
+            self._source_name_or_path = list(set(self._source_name_or_path))
 
     @property
     def yocto_recipe(self):


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- AS-IS: `_source_name_or_path `of OSS Item cannot be initialized.
- TO-BE: Initialize `_source_name_or_path `when assign null.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

