### PR TITLE
Add *sbom_info*.yaml pattern to find oss pkg info file

### DIFF
--- a/src/fosslight_util/parsing_yaml.py
+++ b/src/fosslight_util/parsing_yaml.py
@@ -12,7 +12,7 @@ from .constant import LOGGER_NAME
 from .oss_item import OssItem
 
 _logger = logging.getLogger(LOGGER_NAME)
-SUPPORT_OSS_INFO_FILES = [r"oss-pkg-info[\s\S]*.ya?ml", r"sbom-info[\s\S]*.ya?ml"]
+SUPPORT_OSS_INFO_FILES = [r"oss-pkg-info[\s\S]*.ya?ml", r"sbom(-|_)info[\s\S]*.ya?ml"]
 EXAMPLE_OSS_PKG_INFO_LINK = "https://github.com/fosslight/fosslight_prechecker/blob/main/tests/convert/sbom-info.yaml"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipdist = true
 
 [testenv]
 install_command = pip install {opts} {packages}
-whitelist_externals = cat
+allowlist_externals = cat
                       ls
 setenv =
   PYTHONPATH=.


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
- Add *sbom_info*.yaml pattern to find oss pkg info file.
- Use allowlist_externals instead of whitelist_externals.

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

