### PR TITLE
Fix the bug that can't print excel

### DIFF
--- a/src/fosslight_util/write_excel.py
+++ b/src/fosslight_util/write_excel.py
@@ -180,7 +180,7 @@ def write_result_to_sheet(worksheet, sheet_contents):
     for row_item in sheet_contents:
         worksheet.write(row, 0, row)
         for col_num, value in enumerate(row_item):
-            worksheet.write(row, col_num + 1, value)
+            worksheet.write(row, col_num + 1, str(value))
         row += 1
 
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix the bug that can't print excel.
- Error message : `Fail to generate result file.:Unsupported type <class 'set'> in write()`


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

