### PR TITLE
Fix pygit2 installation error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,14 @@ if __name__ == "__main__":
                      "Programming Language :: Python :: 3.6",
                      "Programming Language :: Python :: 3.7",
                      "Programming Language :: Python :: 3.8",
-                     "Programming Language :: Python :: 3.9", ],
+                     "Programming Language :: Python :: 3.9",
+                     "Programming Language :: Python :: 3.10",
+                     "Programming Language :: Python :: 3.11", ],
         install_requires=required,
         package_data={'fosslight_util': ['resources/frequentLicenselist.json', 'resources/licenses.json']},
         include_package_data=True,
         extras_require={":python_version<'3.7'": ["pygit2==1.6.1"],
-                        ":python_version>'3.6'": ["pygit2==1.10.1"]},
+                        ":python_version>='3.7'": ["pygit2>=1.10.1"]},
         entry_points={
             "console_scripts": [
                 "fosslight_download = fosslight_util.download:main",


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Fix pygit2 installation error on Windows.
- pygit2 installation error on Windows : 
    ```
   Building wheels for collected packages: pygit2, npm, optional-django, progress, py-tlsh, python3-wget, hurry.filesize, sgmllib3k

  Building wheel for pygit2 (pyproject.toml) ... error

  error: subprocess-exited-with-error

 

  × Building wheel for pygit2 (pyproject.toml) did not run successfully.

  │ exit code: 1

  ╰─> [64 lines of output]

      running bdist_wheel

      running build

      running build_py

      creating build

      creating build\lib.win-amd64-cpython-311

      creating build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\blame.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\callbacks.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\config.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\credentials.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\errors.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\ffi.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\index.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\packbuilder.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\refspec.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\remote.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\repository.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\settings.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\submodule.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\utils.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\_build.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\_run.py -> build\lib.win-amd64-cpython-311\pygit2

      copying pygit2\__init__.py -> build\lib.win-amd64-cpython-311\pygit2

      creating build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\attr.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\blame.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\buffer.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\callbacks.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\checkout.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\clone.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\commit.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\common.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\config.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\describe.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\diff.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\errors.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\graph.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\index.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\indexer.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\merge.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\net.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\oid.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\pack.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\proxy.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\refspec.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\remote.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\repository.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\revert.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\stash.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\strarray.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\submodule.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\transport.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\decl\types.h -> build\lib.win-amd64-cpython-311\pygit2\decl

      copying pygit2\_pygit2.pyi -> build\lib.win-amd64-cpython-311\pygit2

      running build_ext

      generating cffi module 'build\\temp.win-amd64-cpython-311\\Release\\pygit2._libgit2.c'

      creating build\temp.win-amd64-cpython-311

      creating build\temp.win-amd64-cpython-311\Release

      building 'pygit2._pygit2' extension

      creating build\temp.win-amd64-cpython-311\Release\src

      "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD "-IC:\Program Files\libgit2\include" -IC:\Users\jiyeong.seok\Downloads\venv\include -IC:\Users\jiyeong.seok\AppData\Local\Programs\Python\Python311\include -IC:\Users\jiyeong.seok\AppData\Local\Programs\Python\Python311\Include "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE" "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\ATLMFC\INCLUDE" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\shared" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\um" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\winrt" /Tcsrc\blob.c /Fobuild\temp.win-amd64-cpython-311\Release\src\blob.obj

      blob.c

      c:\users\jiyeong.seok\appdata\local\temp\pip-install-ija04_t1\pygit2_37f8c68feea54161a517bc032e8f8740\src\diff.h(33): fatal error C1083: 포함 파일을 열 수 없습니다. 'git2.h': No such file or directory

      error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\BIN\\x86_amd64\\cl.exe' failed with exit code 2

      [end of output]
    ```

Ref.
- Reason for defining pygit2 as version 1.10.1 : https://github.com/fosslight/fosslight_util/pull/95 

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

