### PR TITLE
Replace copyright delimiter to comma for csv output

### DIFF
--- a/src/fosslight_util/write_excel.py
+++ b/src/fosslight_util/write_excel.py
@@ -129,6 +129,10 @@ def write_result_to_csv(output_file, sheet_list_origin, separate_sheet=False, ex
                 row_num = 1
                 header_row, sheet_content_without_header = get_header_row(sheet_name, sheet_contents[:], extended_header)
 
+                if 'Copyright Text' in header_row:
+                    idx = header_row.index('Copyright Text')-1
+                    for item in sheet_content_without_header:
+                        item[idx] = item[idx].replace('\n', ', ')
                 if not separate_sheet:
                     merge_sheet.extend(sheet_content_without_header)
                     if sheet_name == list(sheet_list.keys())[-1]:


### PR DESCRIPTION
## Description
Change how to describe multiple copyright for csv output.
Replace the new line to comma for readability of the csv file


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

