### PR TITLE
Fix default file extension bug

### DIFF
--- a/src/fosslight_util/output_format.py
+++ b/src/fosslight_util/output_format.py
@@ -99,6 +99,8 @@ def check_output_formats(output='', formats=[], customized_format={}):
                 output_files = [basename_file for _ in range(len(output_extensions))]
             else:
                 output_path = output
+    if not output_extensions:
+        output_extensions = ['.xlsx']
 
     return success, msg, output_path, output_files, output_extensions
 


### PR DESCRIPTION
## Description
Fix bug related to multiple -f option
Report is not created if both -f and -o are missing
Add .xlsx as defualt file extention


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

