### PR TITLE
Adding external calling function parameter type hints

### DIFF
--- a/src/fosslight_util/convert_excel_to_yaml.py
+++ b/src/fosslight_util/convert_excel_to_yaml.py
@@ -33,7 +33,7 @@ def find_report_file(path_to_find):
     return ""
 
 
-def convert_excel_to_yaml(oss_report_to_read, output_file, sheet_names=""):
+def convert_excel_to_yaml(oss_report_to_read: str, output_file: str, sheet_names: str = "") -> None:
     _file_extension = ".yaml"
     yaml_dict = {}
 

--- a/src/fosslight_util/help.py
+++ b/src/fosslight_util/help.py
@@ -35,12 +35,11 @@ _HELP_MESSAGE_DOWNLOAD = """
 
 
 class PrintHelpMsg():
-    message_suffix = ""
 
-    def __init__(self, value):
+    def __init__(self, value: str = ""):
         self.message_suffix = value
 
-    def print_help_msg(self, exitopt):
+    def print_help_msg(self, exitopt: bool) -> None:
         print(_HELP_MESSAGE_COMMON)
         print(self.message_suffix)
 
@@ -48,7 +47,7 @@ class PrintHelpMsg():
             sys.exit()
 
 
-def print_package_version(pkg_name, msg="", exitopt=True):
+def print_package_version(pkg_name: str, msg: str = "", exitopt: bool = True) -> str:
     if msg == "":
         msg = f"{pkg_name} Version:"
     cur_version = pkg_resources.get_distribution(pkg_name).version

--- a/src/fosslight_util/output_format.py
+++ b/src/fosslight_util/output_format.py
@@ -6,6 +6,7 @@ import os
 from fosslight_util.write_excel import write_result_to_excel, write_result_to_csv
 from fosslight_util.write_opossum import write_opossum
 from fosslight_util.write_yaml import write_yaml
+from typing import Tuple
 
 SUPPORT_FORMAT = {'excel': '.xlsx', 'csv': '.csv', 'opossum': '.json', 'yaml': '.yaml'}
 
@@ -105,7 +106,8 @@ def check_output_formats(output='', formats=[], customized_format={}):
     return success, msg, output_path, output_files, output_extensions
 
 
-def write_output_file(output_file_without_ext, file_extension, sheet_list, extended_header={}, hide_header={}, cover=""):
+def write_output_file(output_file_without_ext: str, file_extension: str, sheet_list: dict, extended_header: dict = {},
+                      hide_header: dict = {}, cover: str = "") -> Tuple[bool, str, str]:
     success = True
     msg = ''
 

--- a/src/fosslight_util/set_log.py
+++ b/src/fosslight_util/set_log.py
@@ -12,6 +12,8 @@ import platform
 from . import constant as constant
 from lastversion import lastversion
 import coloredlogs
+from typing import Tuple
+from logging import Logger
 
 
 def init_check_latest_version(pkg_version="", main_package_name=""):
@@ -42,7 +44,7 @@ class CustomAdapter(logging.LoggerAdapter):
 
 
 def init_log(log_file: str, create_file: bool = True, stream_log_level: int = logging.INFO,
-             file_log_level: int = logging.DEBUG, main_package_name: str = "", path_to_analyze: str = "", path_to_exclude: list = []):
+             file_log_level: int = logging.DEBUG, main_package_name: str = "", path_to_analyze: str = "", path_to_exclude: list = []) -> Tuple[Logger, dict]:
 
     logger = logging.getLogger(constant.LOGGER_NAME)
 

--- a/src/fosslight_util/set_log.py
+++ b/src/fosslight_util/set_log.py
@@ -43,8 +43,8 @@ class CustomAdapter(logging.LoggerAdapter):
         return '[%s] %s' % (self.extra, msg), kwargs
 
 
-def init_log(log_file: str, create_file: bool = True, stream_log_level: int = logging.INFO,
-             file_log_level: int = logging.DEBUG, main_package_name: str = "", path_to_analyze: str = "", path_to_exclude: list = []) -> Tuple[Logger, dict]:
+def init_log(log_file: str, create_file: bool = True, stream_log_level: int = logging.INFO, file_log_level: int = logging.DEBUG,
+             main_package_name: str = "", path_to_analyze: str = "", path_to_exclude: list = []) -> Tuple[Logger, dict]:
 
     logger = logging.getLogger(constant.LOGGER_NAME)
 

--- a/src/fosslight_util/set_log.py
+++ b/src/fosslight_util/set_log.py
@@ -41,8 +41,8 @@ class CustomAdapter(logging.LoggerAdapter):
         return '[%s] %s' % (self.extra, msg), kwargs
 
 
-def init_log(log_file, create_file=True, stream_log_level=logging.INFO,
-             file_log_level=logging.DEBUG, main_package_name="", path_to_analyze="", path_to_exclude=[]):
+def init_log(log_file: str, create_file: bool = True, stream_log_level: int = logging.INFO,
+             file_log_level: int = logging.DEBUG, main_package_name: str = "", path_to_analyze: str = "", path_to_exclude: list = []):
 
     logger = logging.getLogger(constant.LOGGER_NAME)
 

--- a/src/fosslight_util/spdx_licenses.py
+++ b/src/fosslight_util/spdx_licenses.py
@@ -8,6 +8,7 @@ import os
 import sys
 import json
 import traceback
+from typing import Tuple
 
 _resources_dir = 'resources'
 _licenses_json_file = 'licenses.json'
@@ -34,7 +35,7 @@ def get_license_from_nick():
     return licenses
 
 
-def get_spdx_licenses_json():
+def get_spdx_licenses_json() -> Tuple[bool, str, str]:
     success = True
     error_msg = ''
     licenses = ''

--- a/src/fosslight_util/write_excel.py
+++ b/src/fosslight_util/write_excel.py
@@ -45,10 +45,6 @@ def write_excel_and_csv(filename_without_extension: str, sheet_list: dict, ignor
     output_files = ""
     output_csv = ""
 
-    print("=========================")
-    print(type(sheet_list))
-    print("=========================")
-
     is_not_null, sheet_list = remove_empty_sheet(sheet_list)
 
     if is_not_null:

--- a/src/fosslight_util/write_excel.py
+++ b/src/fosslight_util/write_excel.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import fosslight_util.constant as constant
 from jsonmerge import merge
 from fosslight_util.cover import CoverItem
+from typing import Tuple
 
 _HEADER = {'BIN (': ['ID', 'Binary Path', 'Source Code Path',
                      'NOTICE.html', 'OSS Name', 'OSS Version',
@@ -35,13 +36,18 @@ logger = logging.getLogger(constant.LOGGER_NAME)
 COVER_SHEET_NAME = 'Scanner Info'
 
 
-def write_excel_and_csv(filename_without_extension, sheet_list, ignore_os=False, extended_header={}, hide_header={}):
+def write_excel_and_csv(filename_without_extension: str, sheet_list: dict, ignore_os: bool = False,
+                        extended_header: dict = {}, hide_header: dict = {}) -> Tuple[bool, str, str]:
     success = True
     error_msg = ""
     success_csv = True
     error_msg_csv = ""
     output_files = ""
     output_csv = ""
+
+    print("=========================")
+    print(type(sheet_list))
+    print("=========================")
 
     is_not_null, sheet_list = remove_empty_sheet(sheet_list)
 

--- a/src/fosslight_util/write_opossum.py
+++ b/src/fosslight_util/write_opossum.py
@@ -11,7 +11,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import traceback
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import fosslight_util.constant as constant
 
@@ -165,7 +165,7 @@ def make_frequentlicenses():
     return frequentLicenses, success, error_msg
 
 
-def write_opossum(filename, sheet_list):
+def write_opossum(filename: str, sheet_list: dict) -> Tuple[bool, str]:
     success = True
     error_msg = ''
     dict = {}

--- a/src/fosslight_util/write_txt.py
+++ b/src/fosslight_util/write_txt.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 from pathlib import Path
+from typing import Tuple
 
 
-def write_txt_file(file_to_create, str_to_write):
+def write_txt_file(file_to_create: str, str_to_write: str) -> Tuple[bool, str]:
     success = True
     error_msg = ""
     try:

--- a/src/fosslight_util/write_yaml.py
+++ b/src/fosslight_util/write_yaml.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2022 LG Electronics Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+
 import yaml
 import logging
 import os
@@ -11,11 +12,12 @@ from pathlib import Path
 import fosslight_util.constant as constant
 from fosslight_util.oss_item import OssItem
 from fosslight_util.write_excel import _EMPTY_ITEM_MSG
+from typing import Tuple
 
 _logger = logging.getLogger(constant.LOGGER_NAME)
 
 
-def write_yaml(output_file, sheet_list_origin, separate_yaml=False):
+def write_yaml(output_file, sheet_list_origin, separate_yaml=False) -> Tuple[bool, str, str]:
     success = True
     error_msg = ""
     output = ""


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
Python doesn't provide access modifier, so i added type hints based on the methods called by the ~test.py files run in the tox script. However, the type hints provided by Python do not perform static type checking, so they cannot detect runtime errors in advance. Therefore, I think we can consider introducing static type checking in the next step with a tool like Mypy.
As soon as i'm done with this PR, i'll be doing some research on Mypy.

Related: #170 

## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

