### PR TITLE
Improving download performance when cloning based on specific branches or tags

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov
 pytest-flake8
 flake8==3.9.2
 fosslight-source
+GitPython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov
 pytest-flake8
 flake8==3.9.2
 fosslight-source
+spdx-tools==0.8.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,3 @@ pytest-cov
 pytest-flake8
 flake8==3.9.2
 fosslight-source
-GitPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ numpy; python_version < '3.8'
 numpy>=1.22.2; python_version >= '3.8'
 npm
 requests
+GitPython

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -10,7 +10,7 @@ import zipfile
 import logging
 import argparse
 import shutil
-import pygit2 as git
+from git import Repo
 import bz2
 import contextlib
 from datetime import datetime
@@ -230,14 +230,9 @@ def get_github_token(git_url):
 
 
 def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch=""):
-    ref_to_checkout = decide_checkout(checkout_to, tag, branch)
-    msg = ""
     oss_name = get_github_ossname(git_url)
-    oss_version = ""
-    github_token = get_github_token(git_url)
-    callbacks = None
-    if github_token != "":
-        callbacks = git.RemoteCallbacks(credentials=git.UserPass("foo", github_token))  # username is not used, so set to dummy
+    refs_to_checkout = decide_checkout(checkout_to, tag, branch)
+    msg = ""
 
     try:
         if platform.system() != "Windows":
@@ -248,9 +243,18 @@ def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch=""):
             alarm.start()
 
         Path(target_dir).mkdir(parents=True, exist_ok=True)
-        repo = git.clone_repository(git_url, target_dir,
-                                    bare=False, repository=None,
-                                    remote=None, callbacks=callbacks)
+        if refs_to_checkout != "":
+            # gitPython uses the branch argument the same whether you check out to a branch or a tag.
+            repo = Repo.clone_from(git_url, target_dir, branch=refs_to_checkout)
+            logger.info(f"git checkout: {refs_to_checkout}")
+        else:
+            repo = Repo.clone_from(git_url, target_dir)
+
+        if refs_to_checkout != tag:
+            oss_version = repo.active_branch.name
+        else:
+            oss_version = repo.git.describe('--tags')
+
         if platform.system() != "Windows":
             signal.alarm(0)
         else:
@@ -258,20 +262,8 @@ def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch=""):
     except Exception as error:
         logger.warning(f"git clone - failed: {error}")
         msg = str(error)
-        return False, msg, oss_name, oss_version
-    try:
-        if ref_to_checkout != "":
-            ref_list = [x for x in repo.references]
-            ref_to_checkout = get_ref_to_checkout(ref_to_checkout, ref_list)
-            logger.info(f"git checkout: {ref_to_checkout}")
-            repo.checkout(ref_to_checkout)
+        return False, msg, oss_name, refs_to_checkout
 
-            for prefix_ref in prefix_refs:
-                if ref_to_checkout.startswith(prefix_ref):
-                    oss_version = ref_to_checkout[len(prefix_ref):]
-
-    except Exception as error:
-        logger.warning(f"git checkout to {ref_to_checkout} - failed: {error}")
     return True, msg, oss_name, oss_version
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -88,3 +88,53 @@ def test_download_git_clone_with_tag():
     assert len(os.listdir(target_dir)) > 0
     assert oss_name == ''
     assert oss_version == tag_name
+
+
+def test_download_main_branch_when_any_branch_or_tag_not_entered():
+    # given
+    git_url = "https://github.com/LGE-OSS/example"
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
+    expected_oss_name = "main"
+
+    # when
+    success, _, oss_name, oss_version = download_git_clone(git_url, target_dir)
+
+    # then
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0
+    assert oss_name == 'LGE-OSS-example'
+    assert oss_version == expected_oss_name
+
+
+def test_download_main_branch_when_non_existent_branch_entered():
+    # given
+    git_url = "https://github.com/LGE-OSS/example"
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
+    branch_name = "non-existent-branch"
+    expected_oss_name = "main"
+
+    # when
+    success, _, oss_name, oss_version = download_git_clone(git_url, target_dir, branch=branch_name)
+
+    # then
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0
+    assert oss_name == 'LGE-OSS-example'
+    assert oss_version == expected_oss_name
+
+
+def test_download_main_branch_when_non_existent_tag_entered():
+    # given
+    git_url = "https://github.com/LGE-OSS/example"
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
+    tag_name = "non-existent-tag"
+    expected_oss_name = "main"
+
+    # when
+    success, _, oss_name, oss_version = download_git_clone(git_url, target_dir, tag=tag_name)
+
+    # then
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0
+    assert oss_name == 'LGE-OSS-example'
+    assert oss_version == expected_oss_name

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6,14 +6,33 @@ import pytest
 
 from fosslight_util.download import cli_download_and_extract
 from tests import constants
+from git import Repo
 
 
 def test_download_from_github():
-    # when
+    # given
+    git_url = "https://github.com/LGE-OSS/example"
     target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
-    success, _, _, _ = cli_download_and_extract("https://github.com/LGE-OSS/example",
-                                                target_dir,
-                                                "test_result/download_log/example")
+    log_dir = "test_result/download_log/example"
+
+    # when
+    success, _, _, _ = cli_download_and_extract(git_url, target_dir, log_dir)
+
+    # then
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0
+
+
+@pytest.mark.parametrize("git_url",
+                         ["git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git;protocol=git;branch=ci-test",
+                          "git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git;protocol=git;tag=v32"])
+def test_download_from_github_with_branch_or_tag(git_url):
+    # given
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
+    log_dir = "test_result/download_log/example"
+
+    # when
+    success, _, _, _ = cli_download_and_extract(git_url, target_dir, log_dir)
 
     # then
     assert success is True

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -4,9 +4,8 @@
 import os
 import pytest
 
-from fosslight_util.download import cli_download_and_extract
+from fosslight_util.download import cli_download_and_extract, download_git_clone
 from tests import constants
-from git import Repo
 
 
 def test_download_from_github():
@@ -57,3 +56,35 @@ def test_download_from_wget(project_name, project_url):
     # then
     assert success is True
     assert len(os.listdir(target_dir)) > 0
+
+
+def test_download_git_clone_with_branch():
+    # given
+    git_url = "git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
+    branch_name = "ci-test"
+
+    # when
+    success, _, oss_name, oss_version = download_git_clone(git_url, target_dir, branch=branch_name)
+
+    # then
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0
+    assert oss_name == ''
+    assert oss_version == branch_name
+
+
+def test_download_git_clone_with_tag():
+    # given
+    git_url = "git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/example")
+    tag_name = "v32"
+
+    # when
+    success, _, oss_name, oss_version = download_git_clone(git_url, target_dir, tag=tag_name)
+
+    # then
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0
+    assert oss_name == ''
+    assert oss_version == tag_name

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ exclude = .tox/*
 filterwarnings = ignore::DeprecationWarning
 norecursedirs = test_result/* tests/legacy
 
+
 [testenv:test_run]
 deps =
   -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
I refactored the code that was previously using pygit2 to use gitPython. Users can now specify a particular branch or tag and get the corresponding version of the project directly. I measured the performance and saw a download speed improvement of over 65%, as shown in the image attached below. (The project being measured is the [babel project](https://github.com/babel/babel)).

![스크린샷 2024-09-30 오후 8 16 38](https://github.com/user-attachments/assets/97cf0e9a-a7bc-4394-b57c-2532916b6543)


## Type of change
<!--
Please insert 'x' one of the type of change.
 -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Refactoring, Maintenance
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

