### PR TITLE
Download > preserve full dotted-numeric versions for clarified_version

### DIFF
--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -319,6 +319,8 @@ _SEMVER_DOT_QUALIFIER_IN_STR = re.compile(
     re.IGNORECASE,
 )
 _CLARIFIED_MAJOR_ONLY_FULL = re.compile(r'^(?:v\.? ?)?(\d+)$', re.IGNORECASE)
+# Maven / OSGi style: 1.1.7.7 (more than three numeric segments; not strict semver)
+_PURE_DOT_NUMERIC_VERSION = re.compile(r'^\d+(\.\d+)+$')
 # Two-part x.y not followed by .digit (avoids taking "1.2" from "1.2.3")
 _CLARIFIED_TWO_IN_STR = re.compile(r'(\d+)\.(\d+)(?!\.\d)')
 _CLARIFIED_MAJOR_IN_STR = re.compile(
@@ -350,6 +352,9 @@ def clarified_version_from_oss_version(oss_version: str) -> str:
     s = (oss_version or "").strip()
     if not s:
         return ""
+    core = _strip_leading_v_prefix(s)
+    if _PURE_DOT_NUMERIC_VERSION.match(core):
+        return core
     m = _BASE_SEMVER_FOR_CHECKOUT.match(s)
     if m:
         if m.group(3):

--- a/tests/test_download_version_hint.py
+++ b/tests/test_download_version_hint.py
@@ -54,6 +54,12 @@ from fosslight_util.download import (
             "/t/lodash-4.17.21.tgz",
             "4.17.21",
         ),
+        # mvnrepository.com page URL (version is last path segment; four-part Maven version)
+        (
+            "https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.7.7",
+            "",
+            "1.1.7.7",
+        ),
         # Generic: path ends with /download but real version only in filename
         (
             "https://example.com/releases/download",
@@ -81,6 +87,8 @@ def test_oss_version_hint_from_wget_link(link, downloaded_file, expected_hint):
         ("2.31.0", "2.31.0"),
         ("4.17.21", "4.17.21"),
         ("1.1.4", "1.1.4"),
+        ("1.1.7.7", "1.1.7.7"),
+        ("v1.1.7.7", "1.1.7.7"),
         ("v3.28.3", "3.28.3"),
     ],
 )
@@ -93,3 +101,10 @@ def test_github_archive_hint_then_clarified():
     hint = _oss_version_hint_from_wget_link(link, "/t/v3.28.3.tar.gz")
     assert hint == "v3.28.3"
     assert clarified_version_from_oss_version(hint) == "3.28.3"
+
+
+def test_mvnrepository_url_hint_then_clarified():
+    link = "https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.7.7"
+    hint = _oss_version_hint_from_wget_link(link, "")
+    assert hint == "1.1.7.7"
+    assert clarified_version_from_oss_version(hint) == "1.1.7.7"


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
* **Bug Fixes**
  * Improved version clarification logic to better handle numeric version patterns.
  * Enhanced support for Maven repository URL version hint extraction.
      *  Maven/OSGi-style versions like 1.1.7.7 were reduced to trailing x.y (7.7) by the two-part semver heuristic; match pure dotted-numeric strings first after stripping v.


* **Tests**
  * Expanded test coverage for Maven repository URL version hints and clarification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->