### PR TITLE
Add boundary-aware suffix fallback for git checkout ref resolution

### DIFF
--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -514,6 +514,27 @@ def _try_resolve_checkout_base(base: str, ref_set: set) -> Tuple[Optional[str], 
     resolved, ref, clar = _try_semver_checkout(base, ref_set)
     if resolved:
         return ref, clar
+
+    # Fallback: find refs that end with the input version (case-insensitive),
+    # but only when the match starts at a separator boundary (-, _, /, .)
+    # or covers the entire ref. This prevents "2" from matching "3.02".
+    # e.g. input "stable202002" matches branch "edk2-stable202002" (boundary: '-')
+    _BOUNDARY_CHARS = {'-', '_', '/', '.'}
+    base_lower = base.lower()
+    containing_refs = []
+    for r in ref_set:
+        r_lower = r.lower()
+        if not r_lower.endswith(base_lower):
+            continue
+        prefix_len = len(r_lower) - len(base_lower)
+        if prefix_len == 0 or r_lower[prefix_len - 1] in _BOUNDARY_CHARS:
+            containing_refs.append(r)
+    if containing_refs:
+        # Prefer the shortest ref (most specific match)
+        best = min(containing_refs, key=lambda x: (len(x), x.lower()))
+        logger.info(f"Partial match: '{base}' found in ref '{best}'")
+        return best, clarified_version_from_oss_version(best)
+
     return None, None
 
 


### PR DESCRIPTION
## Description
<!--
Please describe what this PR do.
 -->
When exact, v-prefix, and semver matching all fail, fall back to finding refs that end with the input version string at a separator boundary (-, _, /, .). This allows e.g. input "stable202002" to match branch "edk2-stable202002" while preventing false positives like input "2" matching ref "3.02".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version reference resolution with enhanced fallback matching when standard methods fail
  * Now supports case-insensitive partial matching for greater reliability in locating requested versions
  * Prioritizes most specific matches when multiple candidates qualify

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fosslight/fosslight_util/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->