### PR TITLE
Add safe extraction with permission handling for archives

### DIFF
--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -1013,6 +1013,53 @@ def extract_rpm_payload(source_file: str, dest_path: str) -> bool:
     return False
 
 
+def _fix_extracted_permissions(path: str) -> None:
+    try:
+        os.chmod(path, os.stat(path).st_mode | 0o755)
+    except Exception:
+        pass
+    for root, dirs, files in os.walk(path, topdown=True):
+        # Fix dirs BEFORE os.walk recurses into them.
+        for d in dirs:
+            dpath = os.path.join(root, d)
+            try:
+                os.chmod(dpath, os.stat(dpath).st_mode | 0o755)
+            except Exception:
+                pass
+        for f in files:
+            fpath = os.path.join(root, f)
+            try:
+                os.chmod(fpath, os.stat(fpath).st_mode | 0o644)
+            except Exception:
+                pass
+
+
+def _tar_extractall_safe(fname: str, open_mode: str, extract_path: str) -> None:
+    try:
+        with contextlib.closing(tarfile.open(fname, open_mode)) as tf:
+            tf.extractall(path=extract_path)
+    except PermissionError as perm_err:
+        logger.warning(
+            f"Permission error while extracting '{fname}': {perm_err}. "
+            f"Fixing permissions and retrying."
+        )
+        # Fix already-extracted content so the retry can overwrite/descend.
+        _fix_extracted_permissions(extract_path)
+        # Retry with per-member permission normalisation.
+        with contextlib.closing(tarfile.open(fname, open_mode)) as tf:
+            members = tf.getmembers()
+            for m in members:
+                if m.isdir():
+                    m.mode = m.mode | 0o755
+                elif m.isfile():
+                    m.mode = m.mode | 0o644
+            tf.extractall(path=extract_path, members=members)
+    else:
+        # No PermissionError: extractall() may have silently restored 0o000 modes
+        # set by the archive creator, leaving extracted content inaccessible.
+        _fix_extracted_permissions(extract_path)
+
+
 def _extract_top_level_crates_once(extract_path: str, remove_after_extract: bool) -> bool:
     """After RPM/SRPM unpack: extract each ``*.crate`` in extract_path (non-recursive)."""
     if not extract_path or not os.path.isdir(extract_path):
@@ -1025,8 +1072,7 @@ def _extract_top_level_crates_once(extract_path: str, remove_after_extract: bool
         if not os.path.isfile(cp):
             continue
         try:
-            with contextlib.closing(tarfile.open(cp, "r:gz")) as t:
-                t.extractall(path=extract_path)
+            _tar_extractall_safe(cp, "r:gz", extract_path)
             if remove_after_extract:
                 os.remove(cp)
         except Exception as e:
@@ -1058,11 +1104,9 @@ def extract_compressed_file(fname, extract_path, remove_after_extract=True, comp
                 fname = os.path.splitext(fname)[0]
 
             if fname.endswith(".tar.gz") or fname.endswith(".tgz"):
-                with contextlib.closing(tarfile.open(fname, "r:gz")) as t:
-                    t.extractall(path=extract_path)
+                _tar_extractall_safe(fname, "r:gz", extract_path)
             elif fname.endswith(".tar.xz") or fname.endswith(".tar"):
-                with contextlib.closing(tarfile.open(fname, "r:*")) as t:
-                    t.extractall(path=extract_path)
+                _tar_extractall_safe(fname, "r:*", extract_path)
             elif fname.endswith(".zip") or fname.endswith(".jar"):
                 unzip(fname, extract_path)
             elif fname.endswith(".bz2"):
@@ -1093,9 +1137,7 @@ def extract_compressed_file(fname, extract_path, remove_after_extract=True, comp
                     if zipfile.is_zipfile(fname):
                         unzip(fname, extract_path)
                     elif tarfile.is_tarfile(fname):
-                        with contextlib.closing(tarfile.open(fname, "r:*")) as tar:
-                            tar.extraction_filter = getattr(tarfile, 'data_filter', (lambda member, path: member))
-                            tar.extractall(path=extract_path)
+                        _tar_extractall_safe(fname, "r:*", extract_path)
                     else:
                         is_compressed_file = False
                         if compressed_only:

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -1013,51 +1013,82 @@ def extract_rpm_payload(source_file: str, dest_path: str) -> bool:
     return False
 
 
-def _fix_extracted_permissions(path: str) -> None:
-    try:
-        os.chmod(path, os.stat(path).st_mode | 0o755)
-    except Exception:
-        pass
-    for root, dirs, files in os.walk(path, topdown=True):
-        # Fix dirs BEFORE os.walk recurses into them.
-        for d in dirs:
-            dpath = os.path.join(root, d)
-            try:
-                os.chmod(dpath, os.stat(dpath).st_mode | 0o755)
-            except Exception:
-                pass
-        for f in files:
-            fpath = os.path.join(root, f)
-            try:
-                os.chmod(fpath, os.stat(fpath).st_mode | 0o644)
-            except Exception:
-                pass
+def _member_extracted_paths(members, extract_path: str) -> tuple[set, set]:
+    """Return ``(dir_paths, file_paths)`` for tar members under extract_path.
+
+    Members whose normalised name would escape extract_path (path-traversal) are
+    silently skipped, consistent with what tarfile itself does on safe extraction.
+    """
+    abs_extract = os.path.abspath(extract_path)
+    dir_paths: set = set()
+    file_paths: set = set()
+    for m in members:
+        normalized = os.path.normpath(m.name.lstrip('/'))
+        abs_path = os.path.abspath(os.path.join(abs_extract, normalized))
+        try:
+            if os.path.commonpath([abs_path, abs_extract]) == abs_extract:
+                if m.isdir():
+                    dir_paths.add(abs_path)
+                elif m.isfile():
+                    file_paths.add(abs_path)
+        except ValueError:
+            pass
+    return dir_paths, file_paths
+
+
+def _fix_extracted_permissions(member_dirs: set, member_files: set) -> None:
+    """Fix restrictive permissions only for archive member paths.
+
+    This intentionally avoids walking the entire extraction directory so
+    pre-existing local files under ``extract_path`` are never relaxed.
+    """
+    # Directories must be fixed first so nested file paths are traversable.
+    for p in sorted(member_dirs, key=len):
+        try:
+            os.chmod(p, os.stat(p).st_mode | 0o755)
+        except Exception:
+            pass
+
+    for p in sorted(member_files, key=len):
+        try:
+            os.chmod(p, os.stat(p).st_mode | 0o644)
+        except Exception:
+            pass
 
 
 def _tar_extractall_safe(fname: str, open_mode: str, extract_path: str) -> None:
+    members = None
     try:
         with contextlib.closing(tarfile.open(fname, open_mode)) as tf:
+            members = tf.getmembers()
             tf.extractall(path=extract_path)
     except PermissionError as perm_err:
         logger.warning(
             f"Permission error while extracting '{fname}': {perm_err}. "
             f"Fixing permissions and retrying."
         )
-        # Fix already-extracted content so the retry can overwrite/descend.
-        _fix_extracted_permissions(extract_path)
-        # Retry with per-member permission normalisation.
+
+        if members is None:
+            with contextlib.closing(tarfile.open(fname, open_mode)) as tf:
+                members = tf.getmembers()
+        member_dirs, member_files = _member_extracted_paths(members, extract_path)
+        _fix_extracted_permissions(member_dirs, member_files)
+
         with contextlib.closing(tarfile.open(fname, open_mode)) as tf:
-            members = tf.getmembers()
-            for m in members:
+            retry_members = tf.getmembers()
+            for m in retry_members:
                 if m.isdir():
                     m.mode = m.mode | 0o755
                 elif m.isfile():
                     m.mode = m.mode | 0o644
-            tf.extractall(path=extract_path, members=members)
+            tf.extractall(path=extract_path, members=retry_members)
     else:
         # No PermissionError: extractall() may have silently restored 0o000 modes
         # set by the archive creator, leaving extracted content inaccessible.
-        _fix_extracted_permissions(extract_path)
+        if members is None:
+            return
+        member_dirs, member_files = _member_extracted_paths(members, extract_path)
+        _fix_extracted_permissions(member_dirs, member_files)
 
 
 def _extract_top_level_crates_once(extract_path: str, remove_after_extract: bool) -> bool:

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -1044,24 +1044,58 @@ def _fix_extracted_permissions(member_dirs: set, member_files: set) -> None:
     """
     # Directories must be fixed first so nested file paths are traversable.
     for p in sorted(member_dirs, key=len):
+        if not os.path.exists(p):
+            continue
         try:
             os.chmod(p, os.stat(p).st_mode | 0o755)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to fix permissions for directory {p}: {e}")
 
     for p in sorted(member_files, key=len):
+        if not os.path.exists(p):
+            continue
         try:
             os.chmod(p, os.stat(p).st_mode | 0o644)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Failed to fix permissions for file {p}: {e}")
 
 
 def _tar_extractall_safe(fname: str, open_mode: str, extract_path: str) -> None:
+    """Extract tar archive with path-traversal protection.
+
+    On Python >= 3.12, uses tarfile.extractall(filter='data').
+    On older Python, manually validates each member path before extraction.
+    """
     members = None
+    abs_extract = os.path.abspath(extract_path)
+
+    # Check if filter parameter is available (Python >= 3.12)
+    has_filter = hasattr(tarfile, 'data_filter')
+
     try:
         with contextlib.closing(tarfile.open(fname, open_mode)) as tf:
             members = tf.getmembers()
-            tf.extractall(path=extract_path)
+
+            if has_filter:
+                # Python >= 3.12: use built-in filter
+                tf.extractall(path=extract_path, filter='data')
+            else:
+                # Python < 3.12: manual path validation
+                for member in members:
+                    # Compute target path
+                    target = os.path.normpath(os.path.join(extract_path, member.name))
+                    target_abs = os.path.abspath(target)
+
+                    # Verify target is within extract_path
+                    if not (target_abs.startswith(abs_extract + os.sep) or target_abs == abs_extract):
+                        logger.error(
+                            f"Path traversal attempt blocked: {member.name} would extract to {target_abs}"
+                        )
+                        raise ValueError(f"Path traversal attempt in archive member: {member.name}")
+
+                    # Extract individual member
+                    tf.extract(member, path=extract_path)
+
     except PermissionError as perm_err:
         logger.warning(
             f"Permission error while extracting '{fname}': {perm_err}. "
@@ -1081,7 +1115,20 @@ def _tar_extractall_safe(fname: str, open_mode: str, extract_path: str) -> None:
                     m.mode = m.mode | 0o755
                 elif m.isfile():
                     m.mode = m.mode | 0o644
-            tf.extractall(path=extract_path, members=retry_members)
+
+            if has_filter:
+                tf.extractall(path=extract_path, members=retry_members, filter='data')
+            else:
+                # Manual validation on retry
+                for member in retry_members:
+                    target = os.path.normpath(os.path.join(extract_path, member.name))
+                    target_abs = os.path.abspath(target)
+                    if not (target_abs.startswith(abs_extract + os.sep) or target_abs == abs_extract):
+                        logger.error(
+                            f"Path traversal attempt blocked: {member.name} would extract to {target_abs}"
+                        )
+                        raise ValueError(f"Path traversal attempt in archive member: {member.name}")
+                    tf.extract(member, path=extract_path)
     else:
         # No PermissionError: extractall() may have silently restored 0o000 modes
         # set by the archive creator, leaving extracted content inaccessible.
@@ -1145,8 +1192,7 @@ def extract_compressed_file(fname, extract_path, remove_after_extract=True, comp
             elif fname.endswith(".whl"):
                 unzip(fname, extract_path)
             elif fname.endswith(".crate"):
-                with contextlib.closing(tarfile.open(fname, "r:gz")) as t:
-                    t.extractall(path=extract_path)
+                _tar_extractall_safe(fname, "r:gz", extract_path)
             elif fname.lower().endswith(".src.rpm"):
                 if not extract_rpm_payload(fname, extract_path):
                     success = False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive extraction is safer and more reliable: skips path-traversal entries, normalizes file and directory permissions, and retries automatically on permission errors.
  * These improvements apply across multiple archive formats and detection paths, reducing failed or partial extractions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->