### PR TITLE
Resolve validated checkout ref before git clone

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,8 +34,7 @@ jobs:
         pip install tox
     - name: Run Tox
       run: |
-        tox -e release_flake8
-        tox -e release   
+        tox -e release
   reuse:
     runs-on: ubuntu-latest
     steps: 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 tox
 pytest
 pytest-cov
-pytest-flake8
 flake8
 fosslight-source
 pyopenssl>=26.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -576,6 +576,55 @@ def decide_checkout(checkout_to="", tag="", branch="", git_url=""):
     return "", ""
 
 
+def _git_url_with_http_credentials(git_url, id="", git_token=""):
+    """Return git_url with HTTP credentials embedded for ls-remote/clone."""
+    if not (id and git_token):
+        return git_url
+    try:
+        parsed = urllib.parse.urlparse(git_url)
+        if parsed.username or "@" in (parsed.netloc or ""):
+            return git_url
+        m = re.match(r"^(ht|f)tp(s?)\:\/\/", git_url)
+        if not m:
+            return git_url
+        protocol = m.group()
+        encoded_git_token = urllib.parse.quote(git_token, safe='')
+        encoded_id = urllib.parse.quote(id, safe='')
+        return git_url.replace(
+            protocol, f"{protocol}{encoded_id}:{encoded_git_token}@", 1
+        )
+    except Exception as error:
+        logger.info(f"Failed to insert id, token to git url:{error}")
+        return git_url
+
+
+def _resolve_refs_to_checkout(
+    checkout_to="",
+    tag="",
+    branch="",
+    git_url="",
+    id="",
+    git_token="",
+):
+    """Resolve a branch/tag for checkout.
+
+    UI validation may accept user input such as ``5.1.20`` while the remote tag is
+    ``v5.1.20``. Try ``decide_checkout`` first to map to the exact ref name.
+    When ref lookup is unavailable (e.g. private repo), fall back to the user
+    input validated in the UI.
+    """
+    auth_url = _git_url_with_http_credentials(git_url, id, git_token)
+
+    if (checkout_to or "").strip():
+        resolved, clar = decide_checkout(checkout_to, "", "", auth_url)
+        if resolved:
+            return resolved, clar
+        ref = checkout_to.strip()
+        return ref, clarified_version_from_oss_version(ref)
+
+    return decide_checkout("", tag, branch, auth_url)
+
+
 def get_github_ossname(link):
     oss_name = ""
     p = re.compile(r'https?:\/\/github.com\/([^\/]+)\/([^\/\.]+)(\.git)?')
@@ -685,8 +734,8 @@ def download_git_repository(refs_to_checkout, git_url, target_dir, tag, called_c
 def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch="",
                        ssh_key="", id="", git_token="", called_cli=True):
     oss_name = get_github_ossname(git_url)
-    refs_to_checkout, decided_clarified = decide_checkout(
-        checkout_to, tag, branch, git_url
+    refs_to_checkout, decided_clarified = _resolve_refs_to_checkout(
+        checkout_to, tag, branch, git_url, id=id, git_token=git_token
     )
     msg = ""
     success = True
@@ -712,16 +761,7 @@ def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch="",
                 with Git().custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
                     success, oss_version = download_git_repository(refs_to_checkout, git_url, target_dir, tag, called_cli)
             else:
-                if id and git_token:
-                    try:
-                        m = re.match(r"^(ht|f)tp(s?)\:\/\/", git_url)
-                        protocol = m.group()
-                        if protocol:
-                            encoded_git_token = urllib.parse.quote(git_token, safe='')
-                            encoded_id = urllib.parse.quote(id, safe='')
-                            git_url = git_url.replace(protocol, f"{protocol}{encoded_id}:{encoded_git_token}@")
-                    except Exception as error:
-                        logger.info(f"Failed to insert id, token to git url:{error}")
+                git_url = _git_url_with_http_credentials(git_url, id, git_token)
                 success, oss_version = download_git_repository(refs_to_checkout, git_url, target_dir, tag, called_cli)
 
             logger.info(f"git checkout version: {oss_version}")

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -554,12 +554,6 @@ def _try_resolve_checkout_base(base: str, ref_set: set) -> Tuple[Optional[str], 
 
 
 def decide_checkout(checkout_to="", tag="", branch="", git_url=""):
-    """Return (ref_to_checkout, clarified_version). clarified_version may be ''.
-
-    Try tag, then branch, then checkout_to; only if a hint finds no match in refs
-    (same as former final ``return base, clarified_version_from_oss_version(base)``)
-    is the next hint used.
-    """
     ref_dict = get_remote_refs(git_url)
     tag_set = set(ref_dict.get("tags", []))
     branch_set = set(ref_dict.get("branches", []))
@@ -576,9 +570,9 @@ def decide_checkout(checkout_to="", tag="", branch="", git_url=""):
     return "", ""
 
 
-def _git_url_with_http_credentials(git_url, id="", git_token=""):
+def _git_url_with_http_credentials(git_url, credential_id="", git_token=""):
     """Return git_url with HTTP credentials embedded for ls-remote/clone."""
-    if not (id and git_token):
+    if not (credential_id and git_token):
         return git_url
     try:
         parsed = urllib.parse.urlparse(git_url)
@@ -589,11 +583,11 @@ def _git_url_with_http_credentials(git_url, id="", git_token=""):
             return git_url
         protocol = m.group()
         encoded_git_token = urllib.parse.quote(git_token, safe='')
-        encoded_id = urllib.parse.quote(id, safe='')
+        encoded_credential_id = urllib.parse.quote(credential_id, safe='')
         return git_url.replace(
-            protocol, f"{protocol}{encoded_id}:{encoded_git_token}@", 1
+            protocol, f"{protocol}{encoded_credential_id}:{encoded_git_token}@", 1
         )
-    except Exception as error:
+    except (ValueError, TypeError, AttributeError) as error:
         logger.info(f"Failed to insert id, token to git url:{error}")
         return git_url
 
@@ -603,26 +597,22 @@ def _resolve_refs_to_checkout(
     tag="",
     branch="",
     git_url="",
-    id="",
+    credential_id="",
     git_token="",
 ):
-    """Resolve a branch/tag for checkout.
+    auth_url = _git_url_with_http_credentials(git_url, credential_id, git_token)
 
-    UI validation may accept user input such as ``5.1.20`` while the remote tag is
-    ``v5.1.20``. Try ``decide_checkout`` first to map to the exact ref name.
-    When ref lookup is unavailable (e.g. private repo), fall back to the user
-    input validated in the UI.
-    """
-    auth_url = _git_url_with_http_credentials(git_url, id, git_token)
+    # Preserve precedence: tag -> branch -> checkout_to
+    resolved, clar = decide_checkout(checkout_to, tag, branch, auth_url)
+    if resolved:
+        return resolved, clar
 
+    # Fallback when no ref is resolved but checkout_to is provided
     if (checkout_to or "").strip():
-        resolved, clar = decide_checkout(checkout_to, "", "", auth_url)
-        if resolved:
-            return resolved, clar
         ref = checkout_to.strip()
         return ref, clarified_version_from_oss_version(ref)
 
-    return decide_checkout("", tag, branch, auth_url)
+    return "", ""
 
 
 def get_github_ossname(link):
@@ -735,7 +725,7 @@ def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch="",
                        ssh_key="", id="", git_token="", called_cli=True):
     oss_name = get_github_ossname(git_url)
     refs_to_checkout, decided_clarified = _resolve_refs_to_checkout(
-        checkout_to, tag, branch, git_url, id=id, git_token=git_token
+        checkout_to, tag, branch, git_url, credential_id=id, git_token=git_token
     )
     msg = ""
     success = True
@@ -761,7 +751,7 @@ def download_git_clone(git_url, target_dir, checkout_to="", tag="", branch="",
                 with Git().custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
                     success, oss_version = download_git_repository(refs_to_checkout, git_url, target_dir, tag, called_cli)
             else:
-                git_url = _git_url_with_http_credentials(git_url, id, git_token)
+                git_url = _git_url_with_http_credentials(git_url, credential_id=id, git_token=git_token)
                 success, oss_version = download_git_repository(refs_to_checkout, git_url, target_dir, tag, called_cli)
 
             logger.info(f"git checkout version: {oss_version}")

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ install_command = pip install {opts} {packages}
 allowlist_externals = cat
                       ls
                       pytest
+                      flake8
 setenv =
   PYTHONPATH=.
 
@@ -38,13 +39,6 @@ wheel = true
 # move to tests dir
 changedir = {tox_root}/tests
 commands =
+  flake8 {toxinidir}/src
   # Test - run pytest
   pytest
-
-[testenv:release_flake8]
-deps =
-  -r{toxinidir}/requirements-dev.txt
-wheel = true
-commands =
-  # Test - check PEP8
-  pytest -v --flake8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved git clone checkout/ref resolution by using a single credential-aware URL path, and applying safer fallbacks when tags/branches can’t be resolved.
* **Chores**
  * Updated PR CI to run only the release tox environment.
  * Adjusted release testing to include flake8 linting before the existing test run.
  * Removed an unused development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->