### PR TITLE
Hide sheets whose name starts with a dot

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,8 +34,7 @@ jobs:
         pip install tox
     - name: Run Tox
       run: |
-        tox -e release_flake8
-        tox -e release   
+        tox -e release
   reuse:
     runs-on: ubuntu-latest
     steps: 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 tox
 pytest
 pytest-cov
-pytest-flake8
 flake8
 fosslight-source
 pyopenssl>=26.0.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/fosslight_util/write_excel.py
+++ b/src/fosslight_util/write_excel.py
@@ -229,6 +229,10 @@ def hide_column(worksheet, selected_header, hide_header):
                 worksheet.set_column(col_idx, col_idx, None, None, {"hidden": True})
 
 
+def _should_hide_sheet(sheet_name: str) -> bool:
+    return sheet_name.startswith('.')
+
+
 def create_worksheet(workbook, sheet_name, header_row):
     if len(sheet_name) > 31:
         current_time = str(time.time())
@@ -237,6 +241,8 @@ def create_worksheet(workbook, sheet_name, header_row):
     if header_row:
         for col_num, value in enumerate(header_row):
             worksheet.write(0, col_num, value)
+    if _should_hide_sheet(sheet_name):
+        worksheet.hide()
     return worksheet
 
 

--- a/tests/test_write_excel_hidden_sheet.py
+++ b/tests/test_write_excel_hidden_sheet.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+import os
+from copy import deepcopy
+
+import openpyxl
+import pytest
+
+from fosslight_util.output_format import write_output_file
+
+
+@pytest.mark.parametrize("sheet_name, expected_state", [
+    (".test_hidden", "hidden"),
+    ("visible_sheet", "visible"),
+])
+def test_external_sheet_visibility(sheet_name, expected_state, scan_item):
+    output_dir = "test_result/excel_and_csv/excel"
+    os.makedirs(output_dir, exist_ok=True)
+    output_file_without_extension = os.path.join(output_dir, f"Test_{sheet_name.lstrip('.')}")
+
+    scan_item.external_sheets[sheet_name] = [["Col"], ["val"]]
+
+    success, _, result_file = write_output_file(
+        output_file_without_extension, ".xlsx", deepcopy(scan_item)
+    )
+
+    assert success is True
+    workbook = openpyxl.load_workbook(result_file)
+    assert workbook[sheet_name].sheet_state == expected_state

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ install_command = pip install {opts} {packages}
 allowlist_externals = cat
                       ls
                       pytest
+                      flake8
 setenv =
   PYTHONPATH=.
 
@@ -38,13 +39,6 @@ wheel = true
 # move to tests dir
 changedir = {tox_root}/tests
 commands =
+  flake8 {toxinidir}/src
   # Test - run pytest
   pytest
-
-[testenv:release_flake8]
-deps =
-  -r{toxinidir}/requirements-dev.txt
-wheel = true
-commands =
-  # Test - check PEP8
-  pytest -v --flake8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worksheets with names starting with a dot are now hidden in exported Excel files.
  * Visible sheet names continue to appear normally.

* **Tests**
  * Added coverage to verify worksheet visibility in generated `.xlsx` files for both hidden and visible sheet names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->