### PR TITLE
Centralize comment delimiter in COMMENT_DELIMITER constant

### DIFF
--- a/src/fosslight_util/constant.py
+++ b/src/fosslight_util/constant.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 LOGGER_NAME = "FOSSLight"
+COMMENT_DELIMITER = " / "
 
 FL_SOURCE = 'FL_Source'
 FL_DEPENDENCY = 'FL_Dependency'

--- a/src/fosslight_util/oss_item.py
+++ b/src/fosslight_util/oss_item.py
@@ -6,7 +6,7 @@
 import logging
 import os
 import hashlib
-from fosslight_util.constant import LOGGER_NAME, FOSSLIGHT_SCANNER
+from fosslight_util.constant import LOGGER_NAME, FOSSLIGHT_SCANNER, COMMENT_DELIMITER
 from fosslight_util.cover import CoverItem
 from typing import List, Dict
 
@@ -89,7 +89,7 @@ class OssItem:
             self._comment = ""
         else:
             if self._comment:
-                self._comment = f"{self._comment} / {value}"
+                self._comment = f"{self._comment}{COMMENT_DELIMITER}{value}"
             else:
                 self._comment = value
 
@@ -130,7 +130,7 @@ class FileItem:
             self._comment = ""
         else:
             if self._comment:
-                self._comment = f"{self._comment} / {value}"
+                self._comment = f"{self._comment}{COMMENT_DELIMITER}{value}"
             else:
                 self._comment = value
             for oss in self.oss_items:
@@ -207,12 +207,12 @@ class ScannerItem:
     def set_cover_comment(self, value):
         if value:
             if self.cover.comment:
-                self.cover.comment = f"{self.cover.comment} / {value}"
+                self.cover.comment = f"{self.cover.comment}{COMMENT_DELIMITER}{value}"
             else:
                 self.cover.comment = value
 
     def get_cover_comment(self):
-        return [item.strip() for item in self.cover.comment.split(" / ")]
+        return [item.strip() for item in self.cover.comment.split(COMMENT_DELIMITER)]
 
     def append_file_items(self, file_item: List[FileItem], pkg_name=""):
         if pkg_name == "":


### PR DESCRIPTION
Centralize comment delimiter in COMMENT_DELIMITER constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

  * Improved consistency in how multiple comments are combined and separated, reducing formatting issues when viewing or editing comment text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->