### PR TITLE
Fix checksum from file content

### DIFF
--- a/src/fosslight_util/oss_item.py
+++ b/src/fosslight_util/oss_item.py
@@ -12,6 +12,7 @@ from typing import List, Dict
 
 _logger = logging.getLogger(LOGGER_NAME)
 CHECKSUM_NULL = "0"
+_CHECKSUM_CHUNK_SIZE = 1024 * 1024  # 1 MiB
 
 
 class OssItem:
@@ -178,9 +179,11 @@ def get_checksum_sha1(source_name_or_path) -> str:
     checksum = CHECKSUM_NULL
     try:
         if os.path.isfile(source_name_or_path):
-            with open(source_name_or_path, "rb") as f:
-                byte = f.read()
-                checksum = str(hashlib.sha1(byte).hexdigest())
+            sha1 = hashlib.sha1()
+            with open(source_name_or_path, 'rb') as f:
+                for chunk in iter(lambda: f.read(_CHECKSUM_CHUNK_SIZE), b''):
+                    sha1.update(chunk)
+                checksum = sha1.hexdigest()
     except Exception as ex:
         _logger.debug(f"(Error) Get_checksum: {ex}")
 

--- a/src/fosslight_util/oss_item.py
+++ b/src/fosslight_util/oss_item.py
@@ -177,15 +177,12 @@ class FileItem:
 def get_checksum_sha1(source_name_or_path) -> str:
     checksum = CHECKSUM_NULL
     try:
-        checksum = str(hashlib.sha1(source_name_or_path.encode()).hexdigest())
-    except Exception:
-        try:
-            f = open(source_name_or_path, "rb")
-            byte = f.read()
-            checksum = str(hashlib.sha1(byte).hexdigest())
-            f.close()
-        except Exception as ex:
-            _logger.info(f"(Error) Get_checksum: {ex}")
+        if os.path.isfile(source_name_or_path):
+            with open(source_name_or_path, "rb") as f:
+                byte = f.read()
+                checksum = str(hashlib.sha1(byte).hexdigest())
+    except Exception as ex:
+        _logger.debug(f"(Error) Get_checksum: {ex}")
 
     return checksum
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checksum generation: SHA-1 is now computed only when the provided source points to an existing file.
  * When the file can’t be opened/read or an error occurs, the app logs the issue and safely falls back to a null checksum value instead of interrupting normal operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->