### PR TITLE
Support Packagist PHP package source download

### DIFF
--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -203,6 +203,79 @@ def _resolve_debian_search_to_source_tarball(
     return "", ""
 
 
+def _fetch_packagist_packages(package_name: str) -> list:
+    """Return package version entries from Packagist Composer v2 metadata API."""
+    try:
+        r = requests.get(f"https://repo.packagist.org/p2/{package_name}.json", timeout=10)
+        if r.status_code != 200:
+            return []
+        return r.json().get("packages", {}).get(package_name, []) or []
+    except Exception as e:
+        logger.info(f"Fail to fetch packagist metadata ({package_name}): {e}")
+        return []
+
+
+def _packagist_version_candidates(version: str) -> list[str]:
+    v = (version or "").strip()
+    if not v:
+        return []
+    no_v = v[1:] if v.lower().startswith("v") else v
+    candidates = [v, no_v, f"v{no_v}"]
+    return [c for c in dict.fromkeys(candidates) if c]
+
+
+def _find_packagist_package_entry(packages: list, version: str = ""):
+    """Pick a Packagist package entry for version, or the newest entry when version is empty."""
+    if not packages:
+        return None
+    if not version:
+        return packages[0]
+    candidates = _packagist_version_candidates(version)
+    candidate_set = set(candidates)
+    candidate_no_v = {c[1:] if c.lower().startswith("v") else c for c in candidates}
+    for pkg in packages:
+        ver = (pkg.get("version") or "").strip()
+        norm = (pkg.get("version_normalized") or "").strip()
+        ver_no_v = ver[1:] if ver.lower().startswith("v") else ver
+        if ver in candidate_set or norm in candidate_set or ver_no_v in candidate_no_v:
+            return pkg
+    return None
+
+
+def _archive_url_from_packagist_source(source: dict) -> str:
+    """Build a downloadable archive URL from Composer source metadata when dist is missing."""
+    if not source or source.get("type") != "git":
+        return ""
+    src_url = (source.get("url") or "").strip()
+    ref = (source.get("reference") or "").strip()
+    if not src_url or not ref:
+        return ""
+
+    github = re.match(
+        r"https?://(?:www\.)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$",
+        src_url,
+        re.IGNORECASE,
+    )
+    if github:
+        owner, repo = github.group(1), github.group(2)
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return f"https://github.com/{owner}/{repo}/archive/{ref}.zip"
+
+    gitlab = re.match(
+        r"https?://(?:www\.)?gitlab\.com/([^/]+)/([^/]+?)(?:\.git)?/?$",
+        src_url,
+        re.IGNORECASE,
+    )
+    if gitlab:
+        owner, repo = gitlab.group(1), gitlab.group(2)
+        if repo.endswith(".git"):
+            repo = repo[:-4]
+        return f"https://gitlab.com/{owner}/{repo}/-/archive/{ref}/{repo}-{ref}.zip"
+
+    return ""
+
+
 def version_exists(pkg_type, origin_name, version):
     try:
         if pkg_type in ['npm', 'npm2']:
@@ -234,6 +307,9 @@ def version_exists(pkg_type, origin_name, version):
             if r.status_code == 200:
                 listed = r.text.splitlines()
                 return version in listed
+        elif pkg_type == 'packagist':
+            packages = _fetch_packagist_packages(origin_name)
+            return _find_packagist_package_entry(packages, version) is not None
     except Exception as e:
         logger.info(f'version_exists check failed ({pkg_type}:{origin_name}:{version}) {e}')
         return True
@@ -311,6 +387,9 @@ def extract_name_version_from_link(link, checkout_version):
                     elif key == "cargo":
                         oss_name = f"cargo:{origin_name}"
                         oss_version = match.group(2)
+                    elif key == "packagist":
+                        oss_name = f"packagist:{origin_name}"
+                        oss_version = (match.group(2) or match.group(3) or "").strip()
                 except Exception as ex:
                     logger.info(f"extract_name_version_from_link {key}:{ex}")
                 if oss_name:
@@ -323,7 +402,7 @@ def extract_name_version_from_link(link, checkout_version):
         need_latest = False
         if not oss_version and checkout_version:
             oss_version = checkout_version.strip()
-        if pkg_type in ["pypi", "maven", "npm", "npm2", "pub", "go"]:
+        if pkg_type in ["pypi", "maven", "npm", "npm2", "pub", "go", "packagist"]:
             if oss_version:
                 try:
                     if not version_exists(pkg_type, origin_name, oss_version):
@@ -445,6 +524,8 @@ def get_new_link_with_version(link, pkg_type, oss_name, oss_version):
         link = f'https://pkg.go.dev/{oss_name}@{oss_version}'
     elif pkg_type == "cargo":
         link = f'https://crates.io/crates/{oss_name}/{oss_version}'
+    elif pkg_type == "packagist":
+        link = f'https://packagist.org/packages/{oss_name}/{oss_version}'
     return link
 
 
@@ -513,6 +594,11 @@ def get_latest_package_version(link, pkg_type, oss_name):
                 find_version = go_response.json().get('Version')
                 if find_version.startswith('v'):
                     find_version = find_version[1:]
+        elif pkg_type == 'packagist':
+            packages = _fetch_packagist_packages(oss_name)
+            latest_pkg = _find_packagist_package_entry(packages)
+            if latest_pkg:
+                find_version = (latest_pkg.get('version') or '').strip()
     except Exception as e:
         logger.info(f'Fail to get latest package version({link}:{e})')
     return find_version
@@ -546,7 +632,55 @@ def get_downloadable_url(link, checkout_version):
         ret, result_link = get_download_location_for_go(new_link)
     elif pkg_type == "cargo":
         ret, result_link = get_download_location_for_cargo(new_link)
+    elif pkg_type == "packagist" or new_link.startswith('packagist.org/packages/'):
+        ret, result_link = get_download_location_for_packagist(new_link)
     return ret, result_link, oss_name, oss_version, pkg_type
+
+
+def get_download_location_for_packagist(link):
+    """
+    Resolve Packagist package page URL to a direct source archive URL.
+
+    Input examples (https:// stripped by caller):
+      packagist.org/packages/mustache/mustache
+      packagist.org/packages/mustache/mustache/v2.14.2
+      packagist.org/packages/mustache/mustache#v2.14.2
+    """
+    ret = False
+    new_link = ''
+
+    try:
+        matched = re.search(
+            r'packagist\.org/packages/([^/]+/[^/#?]+)(?:/([^/#?]+))?(?:#v?([^/#?]*))?',
+            link,
+        )
+        if not matched:
+            return False, ''
+
+        package_name = matched.group(1)
+        oss_version = (matched.group(2) or matched.group(3) or '').strip()
+        packages = _fetch_packagist_packages(package_name)
+        pkg = _find_packagist_package_entry(packages, oss_version)
+        if not pkg:
+            logger.warning(f'Cannot find packagist package entry ({package_name}:{oss_version or "latest"})')
+            return False, ''
+
+        dist = pkg.get('dist') or {}
+        dist_url = (dist.get('url') or '').strip()
+        if dist_url:
+            return True, dist_url
+
+        source_archive = _archive_url_from_packagist_source(pkg.get('source') or {})
+        if source_archive:
+            return True, source_archive
+
+        logger.warning(
+            f'No dist/source archive for packagist package ({package_name}:{pkg.get("version", "")})'
+        )
+    except Exception as error:
+        logger.warning(f'Cannot find the link for packagist (url:{link}) {error}')
+
+    return ret, new_link
 
 
 def get_download_location_for_cargo(link):

--- a/src/fosslight_util/constant.py
+++ b/src/fosslight_util/constant.py
@@ -41,6 +41,7 @@ SHEET_NAME_FOR_SCANNER = {
 # Cocoapods : https://cocoapods.org/(package)
 # go : https://pkg.go.dev/(package_name_with_slash)@(version)
 # cargo : https://crates.io/crates/(crate_name)/(version)
+# packagist : https://packagist.org/packages/(vendor)/(package)[#v(version)|/(version)]
 PKG_PATTERN = {
     "pypi": r'https?:\/\/pypi\.org\/project\/([^\/]+)[\/]?([^\/]*)',
     "pypi2": r'https?:\/\/files\.pythonhosted\.org\/packages\/source\/[\w]\/([^\/]+)\/[\S]+-([^\-]+)\.tar\.gz',
@@ -53,4 +54,5 @@ PKG_PATTERN = {
     "cocoapods": r'https?:\/\/cocoapods\.org\/pods\/([^\/]+)',
     "go": r'https?:\/\/pkg.go.dev\/([^\@]+)\@?v?([^\/]*)',
     "cargo": r'https?:\/\/crates\.io\/crates\/([^\/]+)\/?([^\/]*)',
+    "packagist": r'https?:\/\/packagist\.org\/packages\/([^\/]+\/[^\/#?]+)(?:\/([^\/#?]+))?(?:\#v?([^\/#?]*))?',
 }

--- a/src/fosslight_util/help.py
+++ b/src/fosslight_util/help.py
@@ -83,6 +83,10 @@ _HELP_MESSAGE_DOWNLOAD = """
 
     # Download and unzip a compressed file
     fosslight_download -s https://example.com/archive.zip -z -t output_dir
+
+    # Download a Packagist (PHP/Composer) package
+    fosslight_download -s https://packagist.org/packages/mustache/mustache -t output_dir
+    fosslight_download -s https://packagist.org/packages/mustache/mustache -c v2.14.2 -t output_dir
 """
 
 

--- a/tests/test_download_packagist.py
+++ b/tests/test_download_packagist.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Packagist (PHP/Composer) download URL resolution."""
+
+import os
+
+import pytest
+
+from fosslight_util import _get_downloadable_url as downloadable_url
+from fosslight_util.download import cli_download_and_extract
+from tests import constants
+
+
+_MUSTACHE_PACKAGES = [
+    {
+        "version": "v3.2.0",
+        "version_normalized": "3.2.0.0",
+        "dist": {
+            "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/abc123",
+            "type": "zip",
+            "reference": "abc123",
+        },
+        "source": {
+            "url": "https://github.com/bobthecow/mustache.php.git",
+            "type": "git",
+            "reference": "abc123",
+        },
+    },
+    {
+        "version": "v2.14.2",
+        "version_normalized": "2.14.2.0",
+        "dist": {
+            "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/def456",
+            "type": "zip",
+            "reference": "def456",
+        },
+        "source": {
+            "url": "https://github.com/bobthecow/mustache.php.git",
+            "type": "git",
+            "reference": "def456",
+        },
+    },
+]
+
+
+class _FakeJsonResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        return self._payload
+
+
+def test_packagist_pattern_extracts_name_and_fragment_version(monkeypatch):
+    monkeypatch.setattr(
+        downloadable_url, "_fetch_packagist_packages", lambda _: _MUSTACHE_PACKAGES
+    )
+    name, version, link, pkg_type = downloadable_url.extract_name_version_from_link(
+        "https://packagist.org/packages/mustache/mustache#v2.14.2",
+        "",
+    )
+    assert pkg_type == "packagist"
+    assert name == "packagist:mustache/mustache"
+    assert version in ("2.14.2", "v2.14.2")
+    assert "mustache/mustache" in link
+
+
+def test_find_packagist_package_entry_matches_with_or_without_v():
+    pkg = downloadable_url._find_packagist_package_entry(_MUSTACHE_PACKAGES, "2.14.2")
+    assert pkg is not None
+    assert pkg["version"] == "v2.14.2"
+
+    pkg = downloadable_url._find_packagist_package_entry(_MUSTACHE_PACKAGES, "v2.14.2")
+    assert pkg is not None
+    assert pkg["version"] == "v2.14.2"
+
+    latest = downloadable_url._find_packagist_package_entry(_MUSTACHE_PACKAGES, "")
+    assert latest["version"] == "v3.2.0"
+
+
+def test_archive_url_from_packagist_source_github():
+    url = downloadable_url._archive_url_from_packagist_source(
+        {
+            "type": "git",
+            "url": "https://github.com/bobthecow/mustache.php.git",
+            "reference": "deadbeef",
+        }
+    )
+    assert url == "https://github.com/bobthecow/mustache.php/archive/deadbeef.zip"
+
+
+def test_get_download_location_for_packagist_uses_dist_url(monkeypatch):
+    def fake_fetch(package_name):
+        assert package_name == "mustache/mustache"
+        return _MUSTACHE_PACKAGES
+
+    monkeypatch.setattr(downloadable_url, "_fetch_packagist_packages", fake_fetch)
+
+    ok, link = downloadable_url.get_download_location_for_packagist(
+        "packagist.org/packages/mustache/mustache/v2.14.2"
+    )
+    assert ok is True
+    assert link == "https://api.github.com/repos/bobthecow/mustache.php/zipball/def456"
+
+
+def test_get_download_location_for_packagist_falls_back_to_source_archive(monkeypatch):
+    packages = [
+        {
+            "version": "v1.0.0",
+            "version_normalized": "1.0.0.0",
+            "dist": {},
+            "source": {
+                "type": "git",
+                "url": "https://github.com/acme/demo.git",
+                "reference": "111aaa",
+            },
+        }
+    ]
+    monkeypatch.setattr(downloadable_url, "_fetch_packagist_packages", lambda _: packages)
+
+    ok, link = downloadable_url.get_download_location_for_packagist(
+        "packagist.org/packages/acme/demo/v1.0.0"
+    )
+    assert ok is True
+    assert link == "https://github.com/acme/demo/archive/111aaa.zip"
+
+
+def test_get_downloadable_url_packagist_latest(monkeypatch):
+    monkeypatch.setattr(
+        downloadable_url, "_fetch_packagist_packages", lambda _: _MUSTACHE_PACKAGES
+    )
+
+    ok, link, oss_name, oss_version, pkg_type = downloadable_url.get_downloadable_url(
+        "https://packagist.org/packages/mustache/mustache",
+        "",
+    )
+    assert ok is True
+    assert pkg_type == "packagist"
+    assert oss_name == "packagist:mustache/mustache"
+    assert oss_version == "v3.2.0"
+    assert link.endswith("/zipball/abc123")
+
+
+def test_get_downloadable_url_packagist_checkout_version(monkeypatch):
+    monkeypatch.setattr(
+        downloadable_url, "_fetch_packagist_packages", lambda _: _MUSTACHE_PACKAGES
+    )
+
+    ok, link, oss_name, oss_version, pkg_type = downloadable_url.get_downloadable_url(
+        "https://packagist.org/packages/mustache/mustache",
+        "v2.14.2",
+    )
+    assert ok is True
+    assert pkg_type == "packagist"
+    assert oss_name == "packagist:mustache/mustache"
+    assert oss_version == "v2.14.2"
+    assert link.endswith("/zipball/def456")
+
+
+@pytest.mark.parametrize(
+    "project_url",
+    [
+        "https://packagist.org/packages/mustache/mustache",
+        "https://packagist.org/packages/mustache/mustache#v2.14.2",
+    ],
+)
+def test_download_packagist_live(project_url):
+    target_dir = os.path.join(constants.TEST_RESULT_DIR, "download/packagist_mustache")
+    log_dir = os.path.join(constants.TEST_RESULT_DIR, "download_log/packagist_mustache")
+
+    success, _, _, _, _ = cli_download_and_extract(project_url, target_dir, log_dir)
+
+    assert success is True
+    assert len(os.listdir(target_dir)) > 0


### PR DESCRIPTION
Resolve packagist.org package URLs via Composer v2 metadata to dist archives (with git source archive fallback) so PHP packages can be downloaded like other registries.

