### PR TITLE
Preserve 0.x.y clarified_version and match npm @scope tages

### DIFF
--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -279,6 +279,7 @@ def cli_download_and_extract(link: str, target_dir: str, log_dir: str, checkout_
     msg_wget = ""
     oss_name = ""
     oss_version = ""
+    clarified_from_git = ""
     downloaded_link = ""
     size_limit_blocked = False
     log_file_name = "fosslight_download_" + \
@@ -305,7 +306,7 @@ def cli_download_and_extract(link: str, target_dir: str, log_dir: str, checkout_
             is_rubygems = src_info.get("rubygems", False)
 
             # General download: git clone → requests → system wget
-            success_git, msg, oss_name, oss_version, _ = download_git_clone(
+            success_git, msg, oss_name, oss_version, clarified_from_git = download_git_clone(
                 link, target_dir, checkout_to, tag, branch,
                 ssh_key, id, git_token, called_cli, size_limit_gb=size_limit_gb)
             link = change_ssh_link_to_https(link)
@@ -367,7 +368,11 @@ def cli_download_and_extract(link: str, target_dir: str, log_dir: str, checkout_
         success = False
         msg = str(error)
 
-    clarified_version = clarified_version_from_oss_version(oss_version)
+    clarified_version = (
+        clarified_from_git
+        if success and clarified_from_git
+        else clarified_version_from_oss_version(oss_version)
+    )
     output_link = downloaded_link if success else ""
     output_result = {
         "success": success,
@@ -446,18 +451,18 @@ _BASE_SEMVER_FOR_CHECKOUT = re.compile(
     re.IGNORECASE,
 )
 _SEMVER_IN_REF = re.compile(
-    r'(?:^v\.? ?|[-_]v\.? ?|[-_])'
+    r'(?:^v\.? ?|[-_@]v\.? ?|[-_@])'
     r'(\d+)\.(\d+)\.(\d+)'
     r'(?:(?:-[0-9A-Za-z.-]+)|(?:\.[A-Za-z][0-9A-Za-z.-]*))?'
     r'(?:\+[0-9A-Za-z.-]+)?'
-    r'(?=[-_]|$)',
+    r'(?=[-_@]|$)',
     re.IGNORECASE,
 )
 _SEMVER_AT_REF_START = re.compile(
     r'^(\d+)\.(\d+)\.(\d+)'
     r'(?:(?:-[0-9A-Za-z.-]+)|(?:\.[A-Za-z][0-9A-Za-z.-]*))?'
     r'(?:\+[0-9A-Za-z.-]+)?'
-    r'(?=[-_]|$)',
+    r'(?=[-_@]|$)',
     re.IGNORECASE,
 )
 _SEMVER_DOT_QUALIFIER_IN_STR = re.compile(
@@ -467,8 +472,11 @@ _SEMVER_DOT_QUALIFIER_IN_STR = re.compile(
 _CLARIFIED_MAJOR_ONLY_FULL = re.compile(r'^(?:v\.? ?)?(\d+)$', re.IGNORECASE)
 # Maven / OSGi style: 1.1.7.7 (more than three numeric segments; not strict semver)
 _PURE_DOT_NUMERIC_VERSION = re.compile(r'^\d+(\.\d+)+$')
-# Two-part x.y not followed by .digit (avoids taking "1.2" from "1.2.3")
-_CLARIFIED_TWO_IN_STR = re.compile(r'(\d+)\.(\d+)(?!\.\d)')
+# Three-part x.y.z anywhere (e.g. R0.3.6, pkg0.3.6) — tried before two-part fallback
+_SEMVER_THREE_IN_STR = re.compile(r'(\d+)\.(\d+)\.(\d+)')
+# Two-part x.y not preceded by digit. and not followed by .digit
+# (avoids taking "3.6" from "0.3.6" or "2.3" from "1.2.3")
+_CLARIFIED_TWO_IN_STR = re.compile(r'(?<!\d\.)(\d+)\.(\d+)(?!\.\d)')
 _CLARIFIED_MAJOR_IN_STR = re.compile(
     r'(?:^|[-_/])(?:v\.? ?)?(\d+)(?=[^.\d]|$)', re.IGNORECASE
 )
@@ -519,6 +527,9 @@ def clarified_version_from_oss_version(oss_version: str) -> str:
     if m:
         return f"{m.group(1)}.{m.group(2)}.{m.group(3)}"
     m = _SEMVER_DOT_QUALIFIER_IN_STR.search(core)
+    if m:
+        return f"{m.group(1)}.{m.group(2)}.{m.group(3)}"
+    m = _SEMVER_THREE_IN_STR.search(core)
     if m:
         return f"{m.group(1)}.{m.group(2)}.{m.group(3)}"
     m = _CLARIFIED_TWO_IN_STR.search(core)
@@ -700,10 +711,11 @@ def _try_resolve_checkout_base(base: str, ref_set: set) -> Tuple[Optional[str], 
         return ref, clar
 
     # Fallback: find refs that end with the input version (case-insensitive),
-    # but only when the match starts at a separator boundary (-, _, /, .)
+    # but only when the match starts at a separator boundary (-, _, /, ., @)
     # or covers the entire ref. This prevents "2" from matching "3.02".
     # e.g. input "stable202002" matches branch "edk2-stable202002" (boundary: '-')
-    _BOUNDARY_CHARS = {'-', '_', '/', '.'}
+    # e.g. input "0.3.6" matches tag "@serenityjs/logger@0.3.6" (boundary: '@')
+    _BOUNDARY_CHARS = {'-', '_', '/', '.', '@'}
     base_lower = base.lower()
     containing_refs = []
     for r in ref_set:

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -558,7 +558,11 @@ def _strip_known_archive_suffixes(filename: str) -> str:
 
 
 def _version_string_from_archive_stem(stem: str) -> str:
-    """Take trailing version segment from name-version stems (e.g. bison-3.8.2 -> 3.8.2)."""
+    """Take trailing version segment from name-version stems (e.g. bison-3.8.2 -> 3.8.2).
+
+    If the basename itself is a version (e.g. v3.28.3, 1.1.7.7), return it.
+    Plain package names without a version (e.g. printf) return "".
+    """
     if not stem:
         return ""
     m = _ARCHIVE_VERSION_TAIL.search(stem)
@@ -570,7 +574,14 @@ def _version_string_from_archive_stem(stem: str) -> str:
         if classifier:
             return classifier.group(1)
         return version
-    return stem
+    core = _strip_leading_v_prefix(_strip_debian_epoch_prefix(stem))
+    if (
+        _PURE_DOT_NUMERIC_VERSION.match(core)
+        or _BASE_SEMVER_FOR_CHECKOUT.match(core)
+        or _CLARIFIED_MAJOR_ONLY_FULL.match(core)
+    ):
+        return stem
+    return ""
 
 
 def _oss_version_hint_from_wget_link(link: str, downloaded_file: str) -> str:
@@ -597,7 +608,9 @@ def _oss_version_hint_from_wget_link(link: str, downloaded_file: str) -> str:
         stem = _strip_known_archive_suffixes(base)
         if not stem or stem.lower() == "download":
             continue
-        return _version_string_from_archive_stem(stem)
+        hint = _version_string_from_archive_stem(stem)
+        if hint:
+            return hint
     return ""
 
 

--- a/tests/test_decide_checkout.py
+++ b/tests/test_decide_checkout.py
@@ -53,6 +53,63 @@ def test_clarified_version_from_repo_prefixed_tag():
     assert clarified_version_from_oss_version("freezed-v2.4.4") == "2.4.4"
 
 
+def test_clarified_version_keeps_leading_zero_major():
+    assert clarified_version_from_oss_version("0.3.6") == "0.3.6"
+    assert clarified_version_from_oss_version("v0.3.6") == "0.3.6"
+
+
+def test_decide_checkout_clarified_keeps_leading_zero_major(monkeypatch):
+    tags = ["0.3.6", "v0.3.6"]
+    monkeypatch.setattr(
+        "fosslight_util.download.get_remote_refs",
+        lambda _url: {"tags": tags, "branches": ["master"]},
+    )
+
+    ref, clar = decide_checkout(
+        checkout_to="0.3.6",
+        git_url="https://github.com/example/pkg",
+    )
+
+    assert ref in ("0.3.6", "v0.3.6")
+    assert clar == "0.3.6"
+
+
+def test_try_resolve_npm_scoped_package_tag():
+    ref_set = {
+        "@serenityjs/logger@0.3.5",
+        "@serenityjs/logger@0.3.6",
+        "@serenityjs/protocol@0.3.6",
+        "master",
+    }
+    ref, clar = _try_resolve_checkout_base("0.3.6", ref_set)
+    assert ref == "@serenityjs/logger@0.3.6"
+    assert clar == "0.3.6"
+
+
+def test_decide_checkout_resolves_npm_scoped_package_tag(monkeypatch):
+    tags = [
+        "@serenityjs/logger@0.3.5",
+        "@serenityjs/logger@0.3.6",
+        "@serenityjs/protocol@0.4.0",
+    ]
+    monkeypatch.setattr(
+        "fosslight_util.download.get_remote_refs",
+        lambda _url: {"tags": tags, "branches": ["main"]},
+    )
+
+    ref, clar = decide_checkout(
+        checkout_to="0.3.6",
+        git_url="https://github.com/SerenityJS/serenity",
+    )
+
+    assert ref == "@serenityjs/logger@0.3.6"
+    assert clar == "0.3.6"
+
+
+def test_clarified_version_from_npm_scoped_tag():
+    assert clarified_version_from_oss_version("@serenityjs/logger@0.3.6") == "0.3.6"
+
+
 def test_decide_checkout_resolves_repo_prefixed_tag(monkeypatch):
     tags = ["freezed-v2.4.4", "freezed_annotation-v2.4.4"]
     monkeypatch.setattr(

--- a/tests/test_download_version_hint.py
+++ b/tests/test_download_version_hint.py
@@ -78,6 +78,17 @@ from fosslight_util import _get_downloadable_url as downloadable_url
             "/wrong/path.txt",
             "1.0.190",
         ),
+        # Archive basename with no version must not become oss_version
+        (
+            "https://web.archive.org/web/20160315015917/http://www.sparetimelabs.com/tinyprintf/printf.zip",
+            "/tmp/printf.zip",
+            "",
+        ),
+        (
+            "https://example.com/files/printf.zip",
+            "",
+            "",
+        ),
     ],
 )
 def test_oss_version_hint_from_wget_link(link, downloaded_file, expected_hint):

--- a/tests/test_download_version_hint.py
+++ b/tests/test_download_version_hint.py
@@ -89,6 +89,8 @@ def test_oss_version_hint_from_wget_link(link, downloaded_file, expected_hint):
     "hint,expected_clarified",
     [
         ("0.2.3", "0.2.3"),
+        ("0.3.6", "0.3.6"),
+        ("v0.3.6", "0.3.6"),
         ("3.8.2", "3.8.2"),
         ("2.31.0", "2.31.0"),
         ("4.17.21", "4.17.21"),
@@ -98,6 +100,13 @@ def test_oss_version_hint_from_wget_link(link, downloaded_file, expected_hint):
         ("v3.28.3", "3.28.3"),
         ("4:10.2.1-1", "10.2.1"),
         ("1:3.118+deb11u1", "3.118"),
+        # Embedded three-part versions must not collapse to trailing x.y
+        ("R0.3.6", "0.3.6"),
+        ("rel0.3.6", "0.3.6"),
+        ("@serenityjs/logger@0.3.6", "0.3.6"),
+        ("1.2.3", "1.2.3"),
+        ("0.3", "0.3"),
+        ("foo-1.2", "1.2"),
     ],
 )
 def test_clarified_follows_hint_for_semver(hint, expected_clarified):


### PR DESCRIPTION
* **Bug Fixes**
  * Improved version detection for Git references, tags, and scoped package names.
  * Preserved leading-zero versions such as `0.3.6` and correctly handled `v`-prefixed versions.
  * Improved checkout selection for references using `@` separators.
  * Prevented incorrect partial matches and version truncation in embedded version strings.
