### PR TITLE
Probe known Maven repos for sources jars

### DIFF
--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -12,6 +12,28 @@ import fosslight_util.constant as constant
 
 logger = logging.getLogger(constant.LOGGER_NAME)
 
+# Probe order for mvnrepository.com → concrete Maven repository hosts.
+# Prefer *-sources.jar (then -source.jar / -src.jar) under each base.
+# Ordered by how commonly these hosts are used in practice.
+MAVEN_REPOSITORY_BASES = (
+    "https://repo1.maven.org/maven2",  # Maven Central
+    "https://dl.google.com/android/maven2",  # Google Android
+    "https://maven.google.com",  # Google Maven
+    "https://repo.spring.io/release",  # Spring
+    "https://repo.spring.io/artifactory/libs-release",  # Spring libs-release
+    "https://plugins.gradle.org/m2",  # Gradle Plugin Portal
+    "https://jitpack.io",  # JitPack (GitHub-based)
+    "https://repository.jboss.org/nexus/content/groups/public",  # JBoss public
+    "https://repository.jboss.org/nexus/content/repositories/releases",  # JBoss releases
+    "https://packages.confluent.io/maven",  # Confluent
+    "https://maven.repository.redhat.com/ga",  # Red Hat GA
+    "https://oss.sonatype.org/content/repositories/releases",  # Sonatype OSS releases
+    "https://repo.clojars.org",  # Clojars
+    "https://packages.atlassian.com/content/repositories/atlassian-public",  # Atlassian
+    "https://repo.hortonworks.com/repository/releases",  # Hortonworks
+)
+MAVEN_SOURCE_CLASSIFIERS = ("sources", "source", "src")
+
 
 def _absolute_packages_debian_url(href: str) -> str:
     if not href:
@@ -826,9 +848,68 @@ def get_download_location_for_pypi(link):
     return ret, new_link
 
 
+def _maven_http_ok(url: str, timeout: float = 8) -> bool:
+    try:
+        response = requests.head(url, allow_redirects=True, timeout=timeout)
+        if response.status_code == 200:
+            return True
+        # Some Maven hosts reject HEAD; fall back to a streamed GET.
+        if response.status_code in (403, 405, 501):
+            response = requests.get(url, stream=True, allow_redirects=True, timeout=timeout)
+            try:
+                return response.status_code == 200
+            finally:
+                response.close()
+    except Exception:
+        return False
+    return False
+
+
+def _maven_sources_from_directory(version_dir: str, artifact_id: str, version: str) -> str:
+    """Parse a Maven version directory listing for a sources jar link."""
+    preferred = f"{artifact_id}-{version}-sources.jar"
+    try:
+        html = urlopen(f"{version_dir.rstrip('/')}/").read().decode("utf8")
+        bs_obj = BeautifulSoup(html, "html.parser")
+        found = ""
+        for anchor in bs_obj.findAll("a"):
+            href = anchor.get("href") or ""
+            text = (anchor.text or "").strip()
+            if text == preferred or href.rstrip("/").endswith(preferred):
+                return f"{version_dir.rstrip('/')}/{href}"
+            if href.endswith(("sources.jar", "source.jar", "src.jar")):
+                found = f"{version_dir.rstrip('/')}/{href}"
+        return found
+    except Exception:
+        return ""
+
+
+def _probe_maven_sources_jar(group_path: str, artifact_id: str, version: str) -> str:
+    for repo_base in MAVEN_REPOSITORY_BASES:
+        version_dir = f"{repo_base}/{group_path}/{artifact_id}/{version}"
+        for classifier in MAVEN_SOURCE_CLASSIFIERS:
+            sources_url = f"{version_dir}/{artifact_id}-{version}-{classifier}.jar"
+            if _maven_http_ok(sources_url):
+                logger.info(f"Maven sources found: {sources_url}")
+                return sources_url
+        listed = _maven_sources_from_directory(version_dir, artifact_id, version)
+        if listed:
+            logger.info(f"Maven sources found via listing: {listed}")
+            return listed
+    return ""
+
+
+def _probe_maven_artifact_base(group_path: str, artifact_id: str) -> str:
+    for repo_base in MAVEN_REPOSITORY_BASES:
+        artifact_base = f"{repo_base}/{group_path}/{artifact_id}"
+        if _maven_http_ok(artifact_base) or _maven_http_ok(f"{artifact_base}/"):
+            logger.info(f"Maven artifact base found: {artifact_base}")
+            return artifact_base
+    return ""
+
+
 def get_download_location_for_maven(link):
-    # get the url for downloading source file in
-    # repo1.maven.org/maven2/(group_id(split to separator '/'))/(artifact_id)/(oss_version)
+    # Resolve a downloadable sources jar (or artifact base when version is absent).
     ret = False
     new_link = ''
 
@@ -842,29 +923,21 @@ def get_download_location_for_maven(link):
             version = parts[2] if len(parts) > 2 and parts[2] else ''
             group_path = group_raw.replace('.', '/')
 
-            repo_base = f'https://repo1.maven.org/maven2/{group_path}/{artifact_id}'
-            try:
-                urlopen(repo_base)
-                if version:
-                    dn_loc = f'{repo_base}/{version}'
-                else:
-                    new_link = repo_base
-                    ret = True
-                    return ret, new_link
-            except Exception:
-                google_base = f'https://dl.google.com/android/maven2/{group_path}/{artifact_id}'
-                if version:
-                    google_sources = f'{google_base}/{version}/{artifact_id}-{version}-sources.jar'
-                    try:
-                        res_g = urlopen(google_sources)
-                        if res_g.getcode() == 200:
-                            ret = True
-                            return ret, google_sources
-                    except Exception:
-                        pass
-                new_link = google_base
-                ret = True
-                return ret, new_link
+            if version:
+                sources_url = _probe_maven_sources_jar(group_path, artifact_id, version)
+                if sources_url:
+                    return True, sources_url
+                raise Exception(
+                    f'no sources jar found in known Maven repositories '
+                    f'for {group_raw}:{artifact_id}:{version}'
+                )
+
+            artifact_base = _probe_maven_artifact_base(group_path, artifact_id)
+            if artifact_base:
+                return True, artifact_base
+            raise Exception(
+                f'artifact not found in known Maven repositories for {group_raw}:{artifact_id}'
+            )
 
         elif link.startswith('repo1.maven.org/maven2/'):
             if link.endswith('.tar.gz') or link.endswith('.jar') or link.endswith('.tar.xz'):

--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -617,7 +617,8 @@ def get_latest_package_version(link, pkg_type, oss_name):
                         break
             if not find_version:
                 maven_response = requests.get(
-                    f'https://api.deps.dev/v3alpha/systems/maven/packages/{oss_name}'
+                    f'https://api.deps.dev/v3alpha/systems/maven/packages/{oss_name}',
+                    timeout=MAVEN_HTTP_TIMEOUT,
                 )
                 if maven_response.status_code == 200:
                     versions = maven_response.json().get('versions', [])

--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -35,6 +35,34 @@ MAVEN_REPOSITORY_BASES = (
     "https://repo.hortonworks.com/repository/releases",  # Hortonworks
 )
 MAVEN_SOURCE_CLASSIFIERS = ("sources", "source", "src")
+# (connect, read) — keep probes snappy; dead hosts must not stall the CLI.
+MAVEN_HTTP_TIMEOUT = (2, 2)
+# groupPath prefix → try these hosts before the default popularity order.
+_MAVEN_GROUP_REPO_HINTS = (
+    ("io/confluent", ("https://packages.confluent.io/maven",)),
+    (
+        "org/springframework",
+        (
+            "https://repo.spring.io/milestone",
+            "https://repo.spring.io/release",
+            "https://repo.spring.io/artifactory/libs-release",
+        ),
+    ),
+    (
+        "com/google/android",
+        ("https://dl.google.com/android/maven2", "https://maven.google.com"),
+    ),
+    (
+        "androidx",
+        ("https://dl.google.com/android/maven2", "https://maven.google.com"),
+    ),
+    (
+        "com/atlassian",
+        ("https://packages.atlassian.com/content/repositories/atlassian-public",),
+    ),
+)
+# Cache sources-jar probe results so version_exists + download resolve once.
+_MAVEN_SOURCES_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 def _absolute_packages_debian_url(href: str) -> str:
@@ -578,7 +606,7 @@ def get_latest_package_version(link, pkg_type, oss_name):
             # Prefer the highest-priority known repository that hosts this package.
             group_path, artifact_id = _maven_group_artifact(oss_name)
             if group_path and artifact_id:
-                for repo_base in MAVEN_REPOSITORY_BASES:
+                for repo_base in _maven_repo_bases_for(group_path):
                     find_version = _maven_latest_version_from_repo(
                         repo_base, group_path, artifact_id
                     )
@@ -876,7 +904,7 @@ def get_download_location_for_pypi(link):
     return ret, new_link
 
 
-def _maven_http_ok(url: str, timeout: float = 8) -> bool:
+def _maven_http_ok(url: str, timeout=MAVEN_HTTP_TIMEOUT) -> bool:
     try:
         response = requests.head(url, allow_redirects=True, timeout=timeout)
         if response.status_code == 200:
@@ -905,18 +933,34 @@ def _maven_group_artifact(origin_name: str) -> tuple[str, str]:
     return group_id.replace('.', '/'), artifact_id
 
 
+def _maven_repo_bases_for(group_path: str) -> tuple[str, ...]:
+    """Prefer host hints matching ``group_path``, then the default popularity order."""
+    preferred: list[str] = []
+    gp = (group_path or "").strip().strip("/")
+    if gp:
+        for prefix, repos in _MAVEN_GROUP_REPO_HINTS:
+            if gp == prefix or gp.startswith(f"{prefix}/"):
+                preferred.extend(repos)
+                break
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for base in (*preferred, *MAVEN_REPOSITORY_BASES):
+        if base not in seen:
+            seen.add(base)
+            ordered.append(base)
+    return tuple(ordered)
+
+
 def _maven_version_available(group_path: str, artifact_id: str, version: str) -> bool:
-    """True if any known Maven host has this exact GAV (sources/pom/jar/dir)."""
-    for repo_base in MAVEN_REPOSITORY_BASES:
-        version_dir = f"{repo_base}/{group_path}/{artifact_id}/{version}"
-        for classifier in MAVEN_SOURCE_CLASSIFIERS:
-            if _maven_http_ok(f"{version_dir}/{artifact_id}-{version}-{classifier}.jar"):
-                return True
-        if _maven_http_ok(f"{version_dir}/{artifact_id}-{version}.pom"):
-            return True
-        if _maven_http_ok(f"{version_dir}/{artifact_id}-{version}.jar"):
-            return True
-        if _maven_http_ok(version_dir) or _maven_http_ok(f"{version_dir}/"):
+    """True if a known host has this GAV as sources jar or pom (reuse sources probe cache)."""
+    if _probe_maven_sources_jar(group_path, artifact_id, version):
+        return True
+    for repo_base in _maven_repo_bases_for(group_path):
+        pom_url = (
+            f"{repo_base}/{group_path}/{artifact_id}/{version}/"
+            f"{artifact_id}-{version}.pom"
+        )
+        if _maven_http_ok(pom_url):
             return True
     return False
 
@@ -925,7 +969,7 @@ def _maven_latest_version_from_repo(repo_base: str, group_path: str, artifact_id
     """Read ``maven-metadata.xml`` and return release/latest/last listed version."""
     metadata_url = f"{repo_base}/{group_path}/{artifact_id}/maven-metadata.xml"
     try:
-        response = requests.get(metadata_url, timeout=8)
+        response = requests.get(metadata_url, timeout=MAVEN_HTTP_TIMEOUT)
         if response.status_code != 200:
             return ""
         root = ET.fromstring(response.content)
@@ -949,8 +993,13 @@ def _maven_sources_from_directory(version_dir: str, artifact_id: str, version: s
     """Parse a Maven version directory listing for a sources jar link."""
     preferred = f"{artifact_id}-{version}-sources.jar"
     try:
-        html = urlopen(f"{version_dir.rstrip('/')}/").read().decode("utf8")
-        bs_obj = BeautifulSoup(html, "html.parser")
+        response = requests.get(
+            f"{version_dir.rstrip('/')}/",
+            timeout=MAVEN_HTTP_TIMEOUT,
+        )
+        if response.status_code != 200:
+            return ""
+        bs_obj = BeautifulSoup(response.text, "html.parser")
         found = ""
         for anchor in bs_obj.findAll("a"):
             href = anchor.get("href") or ""
@@ -965,22 +1014,34 @@ def _maven_sources_from_directory(version_dir: str, artifact_id: str, version: s
 
 
 def _probe_maven_sources_jar(group_path: str, artifact_id: str, version: str) -> str:
-    for repo_base in MAVEN_REPOSITORY_BASES:
+    cache_key = (group_path, artifact_id, version)
+    if cache_key in _MAVEN_SOURCES_PROBE_CACHE:
+        return _MAVEN_SOURCES_PROBE_CACHE[cache_key]
+
+    found = ""
+    for repo_base in _maven_repo_bases_for(group_path):
         version_dir = f"{repo_base}/{group_path}/{artifact_id}/{version}"
         for classifier in MAVEN_SOURCE_CLASSIFIERS:
             sources_url = f"{version_dir}/{artifact_id}-{version}-{classifier}.jar"
             if _maven_http_ok(sources_url):
                 logger.info(f"Maven sources found: {sources_url}")
-                return sources_url
+                found = sources_url
+                break
+        if found:
+            break
+        # Directory listing only when classifier URLs miss; bounded by MAVEN_HTTP_TIMEOUT.
         listed = _maven_sources_from_directory(version_dir, artifact_id, version)
         if listed:
             logger.info(f"Maven sources found via listing: {listed}")
-            return listed
-    return ""
+            found = listed
+            break
+
+    _MAVEN_SOURCES_PROBE_CACHE[cache_key] = found
+    return found
 
 
 def _probe_maven_artifact_base(group_path: str, artifact_id: str) -> str:
-    for repo_base in MAVEN_REPOSITORY_BASES:
+    for repo_base in _maven_repo_bases_for(group_path):
         artifact_base = f"{repo_base}/{group_path}/{artifact_id}"
         if _maven_http_ok(artifact_base) or _maven_http_ok(f"{artifact_base}/"):
             logger.info(f"Maven artifact base found: {artifact_base}")

--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -5,6 +5,7 @@
 import logging
 import re
 import requests
+import xml.etree.ElementTree as ET
 from lastversion import latest
 from bs4 import BeautifulSoup
 from urllib.request import urlopen
@@ -21,6 +22,7 @@ MAVEN_REPOSITORY_BASES = (
     "https://maven.google.com",  # Google Maven
     "https://repo.spring.io/release",  # Spring
     "https://repo.spring.io/artifactory/libs-release",  # Spring libs-release
+    "https://repo.spring.io/milestone",  # Spring milestone
     "https://plugins.gradle.org/m2",  # Gradle Plugin Portal
     "https://jitpack.io",  # JitPack (GitHub-based)
     "https://repository.jboss.org/nexus/content/groups/public",  # JBoss public
@@ -309,14 +311,25 @@ def version_exists(pkg_type, origin_name, version):
             r = requests.get(f"https://pypi.org/pypi/{origin_name}/{version}/json", timeout=5)
             return r.status_code == 200
         elif pkg_type == 'maven':
-            r = requests.get(f'https://api.deps.dev/v3alpha/systems/maven/packages/{origin_name}', timeout=5)
-            if r.status_code == 200:
-                versions = r.json().get('versions', [])
-                for vobj in versions:
-                    vkey = vobj.get('versionKey') or {}
-                    if vkey.get('version') == version:
-                        return True
-                return False
+            # Prefer Central index when available, then probe known Maven hosts for the
+            # exact version so non-Central releases (e.g. Spring milestones) are kept.
+            try:
+                r = requests.get(
+                    f'https://api.deps.dev/v3alpha/systems/maven/packages/{origin_name}',
+                    timeout=5,
+                )
+                if r.status_code == 200:
+                    versions = r.json().get('versions', [])
+                    for vobj in versions:
+                        vkey = vobj.get('versionKey') or {}
+                        if vkey.get('version') == version:
+                            return True
+            except Exception as e:
+                logger.debug(f'Maven Central version index check failed: {e}')
+            group_path, artifact_id = _maven_group_artifact(origin_name)
+            if group_path and artifact_id and version:
+                return _maven_version_available(group_path, artifact_id, version)
+            return False
         elif pkg_type == 'pub':
             r = requests.get(f'https://pub.dev/api/packages/{origin_name}', timeout=5)
             if r.status_code == 200:
@@ -562,50 +575,65 @@ def get_latest_package_version(link, pkg_type, oss_name):
         elif pkg_type == 'pypi':
             find_version = str(latest(oss_name, at='pip', output_format='version', pre_ok=True))
         elif pkg_type == 'maven':
-            maven_response = requests.get(f'https://api.deps.dev/v3alpha/systems/maven/packages/{oss_name}')
-            if maven_response.status_code == 200:
-                versions = maven_response.json().get('versions', [])
-                if versions:
-                    # Some version entries may miss publishedAt; fallback to semantic version ordering.
-                    def sem_key(vstr: str):
-                        # Parse semantic version with optional prerelease label
-                        # Examples: 1.9.0, 1.10.0-alpha, 2.0.0-rc
-                        m = re.match(r'^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-.]([A-Za-z0-9]+))?$', vstr)
-                        if not m:
-                            return (0, 0, 0, 999)
-                        major = int(m.group(1) or 0)
-                        minor = int(m.group(2) or 0)
-                        patch = int(m.group(3) or 0)
-                        label = (m.group(4) or '').lower()
-                        # Assign label weights: stable > rc > beta > alpha
-                        label_weight_map = {
-                            'alpha': -3,
-                            'beta': -2,
-                            'rc': -1
-                        }
-                        weight = label_weight_map.get(label, 0 if label == '' else -4)
-                        return (major, minor, patch, weight)
+            # Prefer the highest-priority known repository that hosts this package.
+            group_path, artifact_id = _maven_group_artifact(oss_name)
+            if group_path and artifact_id:
+                for repo_base in MAVEN_REPOSITORY_BASES:
+                    find_version = _maven_latest_version_from_repo(
+                        repo_base, group_path, artifact_id
+                    )
+                    if find_version:
+                        logger.info(
+                            f'Maven latest version {find_version} from {repo_base}'
+                        )
+                        break
+            if not find_version:
+                maven_response = requests.get(
+                    f'https://api.deps.dev/v3alpha/systems/maven/packages/{oss_name}'
+                )
+                if maven_response.status_code == 200:
+                    versions = maven_response.json().get('versions', [])
+                    if versions:
+                        # Some version entries may miss publishedAt; fallback to semantic version ordering.
+                        def sem_key(vstr: str):
+                            # Parse semantic version with optional prerelease label
+                            # Examples: 1.9.0, 1.10.0-alpha, 2.0.0-rc
+                            m = re.match(r'^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:[-.]([A-Za-z0-9]+))?$', vstr)
+                            if not m:
+                                return (0, 0, 0, 999)
+                            major = int(m.group(1) or 0)
+                            minor = int(m.group(2) or 0)
+                            patch = int(m.group(3) or 0)
+                            label = (m.group(4) or '').lower()
+                            # Assign label weights: stable > rc > beta > alpha
+                            label_weight_map = {
+                                'alpha': -3,
+                                'beta': -2,
+                                'rc': -1
+                            }
+                            weight = label_weight_map.get(label, 0 if label == '' else -4)
+                            return (major, minor, patch, weight)
 
-                    with_pub = [v for v in versions if v.get('publishedAt')]
-                    if with_pub:
-                        cand = max(with_pub, key=lambda v: v.get('publishedAt'))
-                    else:
-                        decorated = []
-                        for v in versions:
-                            vkey = v.get('versionKey', {})
-                            ver = vkey.get('version', '')
-                            if ver:
-                                decorated.append((sem_key(ver), ver, v))
-                        if decorated:
-                            decorated.sort(key=lambda t: t[0])
-                            stable_candidates = [t for t in decorated if t[0][3] == 0]
-                            if stable_candidates:
-                                cand = stable_candidates[-1][2]
-                            else:
-                                cand = decorated[-1][2]
+                        with_pub = [v for v in versions if v.get('publishedAt')]
+                        if with_pub:
+                            cand = max(with_pub, key=lambda v: v.get('publishedAt'))
                         else:
-                            cand = versions[-1]
-                    find_version = cand.get('versionKey', {}).get('version', '')
+                            decorated = []
+                            for v in versions:
+                                vkey = v.get('versionKey', {})
+                                ver = vkey.get('version', '')
+                                if ver:
+                                    decorated.append((sem_key(ver), ver, v))
+                            if decorated:
+                                decorated.sort(key=lambda t: t[0])
+                                stable_candidates = [t for t in decorated if t[0][3] == 0]
+                                if stable_candidates:
+                                    cand = stable_candidates[-1][2]
+                                else:
+                                    cand = decorated[-1][2]
+                            else:
+                                cand = versions[-1]
+                        find_version = cand.get('versionKey', {}).get('version', '')
         elif pkg_type == 'pub':
             pub_response = requests.get(f'https://pub.dev/api/packages/{oss_name}')
             if pub_response.status_code == 200:
@@ -863,6 +891,58 @@ def _maven_http_ok(url: str, timeout: float = 8) -> bool:
     except Exception:
         return False
     return False
+
+
+def _maven_group_artifact(origin_name: str) -> tuple[str, str]:
+    """Return ``(group_path, artifact_id)`` from ``groupId:artifactId``."""
+    if not origin_name or ':' not in origin_name:
+        return "", ""
+    group_id, artifact_id = origin_name.split(':', 1)
+    group_id = group_id.strip()
+    artifact_id = artifact_id.strip()
+    if not group_id or not artifact_id:
+        return "", ""
+    return group_id.replace('.', '/'), artifact_id
+
+
+def _maven_version_available(group_path: str, artifact_id: str, version: str) -> bool:
+    """True if any known Maven host has this exact GAV (sources/pom/jar/dir)."""
+    for repo_base in MAVEN_REPOSITORY_BASES:
+        version_dir = f"{repo_base}/{group_path}/{artifact_id}/{version}"
+        for classifier in MAVEN_SOURCE_CLASSIFIERS:
+            if _maven_http_ok(f"{version_dir}/{artifact_id}-{version}-{classifier}.jar"):
+                return True
+        if _maven_http_ok(f"{version_dir}/{artifact_id}-{version}.pom"):
+            return True
+        if _maven_http_ok(f"{version_dir}/{artifact_id}-{version}.jar"):
+            return True
+        if _maven_http_ok(version_dir) or _maven_http_ok(f"{version_dir}/"):
+            return True
+    return False
+
+
+def _maven_latest_version_from_repo(repo_base: str, group_path: str, artifact_id: str) -> str:
+    """Read ``maven-metadata.xml`` and return release/latest/last listed version."""
+    metadata_url = f"{repo_base}/{group_path}/{artifact_id}/maven-metadata.xml"
+    try:
+        response = requests.get(metadata_url, timeout=8)
+        if response.status_code != 200:
+            return ""
+        root = ET.fromstring(response.content)
+        for tag in ("release", "latest"):
+            value = (root.findtext(f"versioning/{tag}") or "").strip()
+            if value:
+                return value
+        versions = [
+            (node.text or "").strip()
+            for node in root.findall("versioning/versions/version")
+            if (node.text or "").strip()
+        ]
+        if versions:
+            return versions[-1]
+    except Exception as ex:
+        logger.debug(f"Failed to read Maven metadata ({metadata_url}): {ex}")
+    return ""
 
 
 def _maven_sources_from_directory(version_dir: str, artifact_id: str, version: str) -> str:

--- a/src/fosslight_util/download.py
+++ b/src/fosslight_util/download.py
@@ -352,15 +352,15 @@ def cli_download_and_extract(link: str, target_dir: str, log_dir: str, checkout_
         if size_limit_blocked:
             # Keep a clear size-limit message for callers/UI (do not wrap as git/wget fail)
             pass
+        elif success:
+            # wget/gem may succeed after git failed; do not keep leftover git fail text
+            msg = ""
         elif msg:
             msg = f'git fail: {msg}'
             if is_rubygems:
                 msg = f'gem download: {success}'
-            else:
-                if msg_wget:
-                    msg = f'{msg}, wget fail: {msg_wget}'
-                else:
-                    msg = f'{msg}, wget success'
+            elif msg_wget:
+                msg = f'{msg}, wget fail: {msg_wget}'
         elif msg_wget:
             msg = f'wget fail: {msg_wget}'
 

--- a/tests/test_download_maven.py
+++ b/tests/test_download_maven.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 LG Electronics Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Maven repository probing and exact-version preference."""
+
+import pytest
+
+from fosslight_util import _get_downloadable_url as downloadable_url
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, text="", content=b""):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+        self.text = text
+        self.content = content
+
+    def json(self):
+        return self._payload
+
+    def close(self):
+        return None
+
+
+def test_version_exists_keeps_non_central_maven_version(monkeypatch):
+    """Central index miss must not reject a version hosted on another known repo."""
+
+    def fake_get(url, timeout=5):
+        assert "deps.dev" in url
+        return _FakeResponse(200, {"versions": [{"versionKey": {"version": "6.1.14"}}]})
+
+    monkeypatch.setattr(downloadable_url.requests, "get", fake_get)
+    monkeypatch.setattr(
+        downloadable_url,
+        "_maven_version_available",
+        lambda group_path, artifact_id, version: (
+            group_path == "org/springframework"
+            and artifact_id == "spring-core"
+            and version == "6.2.0-M1"
+        ),
+    )
+
+    assert downloadable_url.version_exists(
+        "maven", "org.springframework:spring-core", "6.2.0-M1"
+    ) is True
+    assert downloadable_url.version_exists(
+        "maven", "org.springframework:spring-core", "9.9.9"
+    ) is False
+
+
+def test_extract_keeps_exact_version_when_found_on_candidate_repo(monkeypatch):
+    monkeypatch.setattr(
+        downloadable_url,
+        "version_exists",
+        lambda pkg_type, origin_name, version: version == "6.2.0-M1",
+    )
+    monkeypatch.setattr(
+        downloadable_url,
+        "get_latest_package_version",
+        lambda *_args, **_kwargs: pytest.fail("latest fallback must not run"),
+    )
+
+    name, version, link, pkg_type = downloadable_url.extract_name_version_from_link(
+        "https://mvnrepository.com/artifact/org.springframework/spring-core/6.2.0-M1",
+        "",
+    )
+    assert pkg_type == "maven"
+    assert name == "org.springframework:spring-core"
+    assert version == "6.2.0-M1"
+    assert link.endswith("/spring-core/6.2.0-M1")
+
+
+def test_extract_falls_back_to_latest_only_when_no_repo_has_version(monkeypatch):
+    monkeypatch.setattr(
+        downloadable_url,
+        "version_exists",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        downloadable_url,
+        "get_latest_package_version",
+        lambda *_args, **_kwargs: "6.1.14",
+    )
+
+    name, version, link, pkg_type = downloadable_url.extract_name_version_from_link(
+        "https://mvnrepository.com/artifact/org.springframework/spring-core/9.9.9-NOT-EXIST",
+        "",
+    )
+    assert pkg_type == "maven"
+    assert name == "org.springframework:spring-core"
+    assert version == "6.1.14"
+    assert link.endswith("/spring-core/6.1.14")
+
+
+def test_probe_maven_sources_prefers_repo_with_exact_version(monkeypatch):
+    central = "https://repo1.maven.org/maven2"
+    spring_milestone = "https://repo.spring.io/milestone"
+    monkeypatch.setattr(
+        downloadable_url,
+        "MAVEN_REPOSITORY_BASES",
+        (central, spring_milestone),
+    )
+
+    def fake_http_ok(url, timeout=8):
+        return (
+            url
+            == f"{spring_milestone}/org/springframework/spring-core/6.2.0-M1/"
+            "spring-core-6.2.0-M1-sources.jar"
+        )
+
+    monkeypatch.setattr(downloadable_url, "_maven_http_ok", fake_http_ok)
+    monkeypatch.setattr(
+        downloadable_url,
+        "_maven_sources_from_directory",
+        lambda *_args, **_kwargs: "",
+    )
+
+    found = downloadable_url._probe_maven_sources_jar(
+        "org/springframework", "spring-core", "6.2.0-M1"
+    )
+    assert found == (
+        f"{spring_milestone}/org/springframework/spring-core/6.2.0-M1/"
+        "spring-core-6.2.0-M1-sources.jar"
+    )
+
+
+def test_get_download_location_for_maven_uses_candidate_sources(monkeypatch):
+    expected = (
+        "https://packages.confluent.io/maven/io/confluent/"
+        "kafka-avro-serializer/8.2.1/kafka-avro-serializer-8.2.1-sources.jar"
+    )
+    monkeypatch.setattr(
+        downloadable_url,
+        "_probe_maven_sources_jar",
+        lambda group_path, artifact_id, version: expected
+        if (group_path, artifact_id, version)
+        == ("io/confluent", "kafka-avro-serializer", "8.2.1")
+        else "",
+    )
+
+    ok, url = downloadable_url.get_download_location_for_maven(
+        "mvnrepository.com/artifact/io.confluent/kafka-avro-serializer/8.2.1"
+    )
+    assert ok is True
+    assert url == expected
+
+
+def test_get_latest_package_version_uses_highest_priority_repo_metadata(monkeypatch):
+    central = "https://repo1.maven.org/maven2"
+    spring = "https://repo.spring.io/milestone"
+    monkeypatch.setattr(
+        downloadable_url,
+        "MAVEN_REPOSITORY_BASES",
+        (central, spring),
+    )
+
+    def fake_latest(repo_base, group_path, artifact_id):
+        assert group_path == "org/springframework"
+        assert artifact_id == "spring-core"
+        if repo_base == central:
+            return "6.1.14"
+        if repo_base == spring:
+            return "6.2.0-M1"
+        return ""
+
+    monkeypatch.setattr(downloadable_url, "_maven_latest_version_from_repo", fake_latest)
+    # deps.dev must not be consulted when a high-priority repo already answered.
+    monkeypatch.setattr(
+        downloadable_url.requests,
+        "get",
+        lambda *_args, **_kwargs: pytest.fail("deps.dev fallback must not run"),
+    )
+
+    latest = downloadable_url.get_latest_package_version(
+        "https://mvnrepository.com/artifact/org.springframework/spring-core",
+        "maven",
+        "org.springframework:spring-core",
+    )
+    assert latest == "6.1.14"
+
+
+def test_maven_latest_version_from_repo_parses_metadata(monkeypatch):
+    xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <metadata>
+      <versioning>
+        <latest>6.2.0-M3</latest>
+        <release>6.1.14</release>
+        <versions>
+          <version>6.1.13</version>
+          <version>6.1.14</version>
+          <version>6.2.0-M3</version>
+        </versions>
+      </versioning>
+    </metadata>
+    """
+
+    monkeypatch.setattr(
+        downloadable_url.requests,
+        "get",
+        lambda *_args, **_kwargs: _FakeResponse(200, content=xml),
+    )
+    assert (
+        downloadable_url._maven_latest_version_from_repo(
+            "https://repo1.maven.org/maven2",
+            "org/springframework",
+            "spring-core",
+        )
+        == "6.1.14"
+    )

--- a/tests/test_download_maven.py
+++ b/tests/test_download_maven.py
@@ -99,8 +99,9 @@ def test_probe_maven_sources_prefers_repo_with_exact_version(monkeypatch):
         "MAVEN_REPOSITORY_BASES",
         (central, spring_milestone),
     )
+    downloadable_url._MAVEN_SOURCES_PROBE_CACHE.clear()
 
-    def fake_http_ok(url, timeout=8):
+    def fake_http_ok(url, timeout=None):
         return (
             url
             == f"{spring_milestone}/org/springframework/spring-core/6.2.0-M1/"
@@ -121,6 +122,49 @@ def test_probe_maven_sources_prefers_repo_with_exact_version(monkeypatch):
         f"{spring_milestone}/org/springframework/spring-core/6.2.0-M1/"
         "spring-core-6.2.0-M1-sources.jar"
     )
+
+
+def test_maven_repo_bases_for_prefers_group_hints():
+    bases = downloadable_url._maven_repo_bases_for("io/confluent")
+    assert bases[0] == "https://packages.confluent.io/maven"
+    assert "https://repo1.maven.org/maven2" in bases
+
+    spring_bases = downloadable_url._maven_repo_bases_for("org/springframework")
+    assert spring_bases[0] == "https://repo.spring.io/milestone"
+
+
+def test_probe_maven_sources_reuses_cache(monkeypatch):
+    downloadable_url._MAVEN_SOURCES_PROBE_CACHE.clear()
+    calls = {"n": 0}
+
+    def fake_http_ok(url, timeout=None):
+        calls["n"] += 1
+        return url.endswith("common-utils-8.2.1-sources.jar") and "packages.confluent.io" in url
+
+    monkeypatch.setattr(downloadable_url, "_maven_http_ok", fake_http_ok)
+    monkeypatch.setattr(
+        downloadable_url,
+        "_maven_sources_from_directory",
+        lambda *_args, **_kwargs: "",
+    )
+    monkeypatch.setattr(
+        downloadable_url,
+        "MAVEN_REPOSITORY_BASES",
+        (
+            "https://repo1.maven.org/maven2",
+            "https://packages.confluent.io/maven",
+        ),
+    )
+
+    first = downloadable_url._probe_maven_sources_jar(
+        "io/confluent", "common-utils", "8.2.1"
+    )
+    second = downloadable_url._probe_maven_sources_jar(
+        "io/confluent", "common-utils", "8.2.1"
+    )
+    assert first == second
+    assert first.endswith("common-utils-8.2.1-sources.jar")
+    assert calls["n"] == 1  # second call served from cache
 
 
 def test_get_download_location_for_maven_uses_candidate_sources(monkeypatch):
@@ -149,8 +193,8 @@ def test_get_latest_package_version_uses_highest_priority_repo_metadata(monkeypa
     spring = "https://repo.spring.io/milestone"
     monkeypatch.setattr(
         downloadable_url,
-        "MAVEN_REPOSITORY_BASES",
-        (central, spring),
+        "_maven_repo_bases_for",
+        lambda group_path: (central, spring),
     )
 
     def fake_latest(repo_base, group_path, artifact_id):

--- a/tests/test_download_version_hint.py
+++ b/tests/test_download_version_hint.py
@@ -288,6 +288,7 @@ def test_cli_output_result_includes_downloaded_link(tmp_path, monkeypatch):
 
     assert result["success"] is True
     assert result["link"] == "http://deb.debian.org/debian/pool/main/p/pkg/pkg_1.0.0.tar.xz"
+    assert result["message"] == ""
 
 
 def test_cli_output_result_uses_empty_link_on_failure(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Maven downloads now search multiple repositories for artifacts, source JARs, versions, and metadata.
  * Maven version detection and latest-version lookup provide more reliable results across repositories.

* **Bug Fixes**
  * Improved download result messages by avoiding misleading success text and ensuring an empty message is returned on success.

* **Tests**
  * Added coverage for Maven repository discovery, metadata handling, version resolution, source downloads, and CLI download results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->