### PR TITLE
Resolve npm registry tarball urls and honor checkout version

### DIFF
--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -704,11 +704,16 @@ def get_downloadable_url(link, checkout_version):
     elif pkg_type == "maven" or new_link.startswith('repo1.maven.org/') or new_link.startswith('dl.google.com/android/maven2/'):
         ret, result_link = get_download_location_for_maven(new_link)
     elif (pkg_type in ["npm", "npm2"]) or new_link.startswith('registry.npmjs.org/'):
-        ret, result_link = get_download_location_for_npm(new_link, checkout_version)
-        if ret and not oss_version and checkout_version:
-            is_tarball = '/-/' in new_link and new_link.rstrip('/').endswith('.tgz')
-            if not is_tarball:
-                oss_version = checkout_version.strip()
+        ret, result_link, npm_name, npm_version, npm_pkg_type = get_download_location_for_npm(
+            new_link, checkout_version
+        )
+        if ret:
+            if not oss_name and npm_name:
+                oss_name = npm_name
+            if not oss_version and npm_version:
+                oss_version = npm_version
+            if not pkg_type and npm_pkg_type:
+                pkg_type = npm_pkg_type
     elif pkg_type == "pub":
         ret, result_link = get_download_location_for_pub(new_link)
     elif pkg_type == "go":
@@ -1126,6 +1131,35 @@ def get_download_location_for_maven(link):
     return ret, new_link
 
 
+def _npm_pkg_type(package_name):
+    return 'npm2' if package_name.startswith('@') else 'npm'
+
+
+def _npm_oss_name(package_name):
+    return f'npm:{package_name}' if package_name else ''
+
+
+def _npm_package_name_from_tarball_link(link):
+    path = link.split('registry.npmjs.org/', 1)[-1]
+    parts = path.split('/')
+    if not parts or not parts[0]:
+        return ''
+    if parts[0].startswith('@'):
+        if len(parts) > 1:
+            return f'{parts[0]}/{parts[1]}'
+        return parts[0]
+    return parts[0]
+
+
+def _npm_version_from_tarball_link(link):
+    match = re.search(r'/([^/]+)\.tgz/?$', link.rstrip('/'))
+    if not match:
+        return ''
+    stem = match.group(1)
+    parts = stem.rsplit('-', 1)
+    return parts[-1] if len(parts) > 1 else ''
+
+
 def _parse_npm_package_link(link):
     """Parse npm registry/npmjs.com URL into (package_name, version or None)."""
     parts = link.split('/')
@@ -1153,27 +1187,40 @@ def _parse_npm_package_link(link):
 def get_download_location_for_npm(link, checkout_version=""):
     ret = False
     new_link = ''
+    oss_name = ''
+    oss_version = ''
+    pkg_type = ''
 
     link = link.replace('%40', '@')
     if not (link.startswith('www.npmjs.com/') or link.startswith('registry.npmjs.org/')):
-        return ret, new_link
+        return ret, new_link, oss_name, oss_version, pkg_type
 
     # Type A: already a tarball URL (scoped/unscoped)
     if '/-/' in link and link.rstrip('/').endswith('.tgz'):
-        return True, f'https://{link.lstrip("https://").lstrip("http://")}'
+        package_name = _npm_package_name_from_tarball_link(link)
+        tarball_url = f'https://{link.lstrip("https://").lstrip("http://")}'
+        return (
+            True,
+            tarball_url,
+            _npm_oss_name(package_name),
+            _npm_version_from_tarball_link(link),
+            _npm_pkg_type(package_name) if package_name else '',
+        )
 
     # Type B: package page URL — resolve via registry API
     try:
-        oss_name_npm, oss_version = _parse_npm_package_link(link)
-        if not oss_name_npm:
-            return ret, new_link
+        package_name, oss_version = _parse_npm_package_link(link)
+        if not package_name:
+            return ret, new_link, oss_name, oss_version, pkg_type
+        oss_name = _npm_oss_name(package_name)
+        pkg_type = _npm_pkg_type(package_name)
         if not oss_version and checkout_version:
             oss_version = checkout_version.strip()
 
         if oss_version:
-            api_url = f'https://registry.npmjs.org/{oss_name_npm}/{oss_version}'
+            api_url = f'https://registry.npmjs.org/{package_name}/{oss_version}'
         else:
-            api_url = f'https://registry.npmjs.org/{oss_name_npm}'
+            api_url = f'https://registry.npmjs.org/{package_name}'
 
         npm_response = requests.get(api_url, timeout=5)
         if npm_response.status_code == 200:
@@ -1184,6 +1231,7 @@ def get_download_location_for_npm(link, checkout_version=""):
                 latest_ver = data.get('dist-tags', {}).get('latest', '')
                 tarball = ''
                 if latest_ver:
+                    oss_version = latest_ver
                     tarball = data.get('versions', {}).get(latest_ver, {}).get('dist', {}).get('tarball', '')
             if tarball:
                 new_link = tarball
@@ -1192,7 +1240,7 @@ def get_download_location_for_npm(link, checkout_version=""):
         ret = False
         logger.warning('Cannot find the link for npm (url:'+link+') '+str(error))
 
-    return ret, new_link
+    return ret, new_link, oss_name, oss_version, pkg_type
 
 
 def get_download_location_for_pub(link):

--- a/src/fosslight_util/_get_downloadable_url.py
+++ b/src/fosslight_util/_get_downloadable_url.py
@@ -704,7 +704,11 @@ def get_downloadable_url(link, checkout_version):
     elif pkg_type == "maven" or new_link.startswith('repo1.maven.org/') or new_link.startswith('dl.google.com/android/maven2/'):
         ret, result_link = get_download_location_for_maven(new_link)
     elif (pkg_type in ["npm", "npm2"]) or new_link.startswith('registry.npmjs.org/'):
-        ret, result_link = get_download_location_for_npm(new_link)
+        ret, result_link = get_download_location_for_npm(new_link, checkout_version)
+        if ret and not oss_version and checkout_version:
+            is_tarball = '/-/' in new_link and new_link.rstrip('/').endswith('.tgz')
+            if not is_tarball:
+                oss_version = checkout_version.strip()
     elif pkg_type == "pub":
         ret, result_link = get_download_location_for_pub(new_link)
     elif pkg_type == "go":
@@ -1122,37 +1126,72 @@ def get_download_location_for_maven(link):
     return ret, new_link
 
 
-def get_download_location_for_npm(link):
-    # url format : registry.npmjs.org/packagename/-/packagename-version.tgz
+def _parse_npm_package_link(link):
+    """Parse npm registry/npmjs.com URL into (package_name, version or None)."""
+    parts = link.split('/')
+    idx = 2 if len(parts) > 1 and parts[1] == 'package' else 1
+    if idx >= len(parts):
+        return None, None
+
+    if parts[idx].startswith('@'):
+        if idx + 1 >= len(parts):
+            return parts[idx], None
+        package_name = f'{parts[idx]}/{parts[idx + 1]}'
+        version_idx = idx + 2
+    else:
+        package_name = parts[idx]
+        version_idx = idx + 1
+
+    version = None
+    remaining = parts[version_idx:]
+    if remaining and remaining[0] == 'v' and len(remaining) > 1:
+        version = remaining[1].rstrip('/')
+
+    return package_name, version
+
+
+def get_download_location_for_npm(link, checkout_version=""):
     ret = False
     new_link = ''
-    oss_version = ""
-    oss_name_npm = ""
-    tar_name = ""
 
     link = link.replace('%40', '@')
-    if link.startswith('www.npmjs.com/') or link.startswith('registry.npmjs.org/'):
-        try:
-            dn_loc_split = link.split('/')
-            if dn_loc_split[1] == 'package':
-                idx = 2
-            else:
-                idx = 1
-            if dn_loc_split[idx].startswith('@'):
-                oss_name_npm = dn_loc_split[idx]+'/'+dn_loc_split[idx+1]
-                tar_name = dn_loc_split[idx+1]
-                oss_version = dn_loc_split[idx+3]
-            else:
-                oss_name_npm = dn_loc_split[idx]
-                tar_name = oss_name_npm
-                oss_version = dn_loc_split[idx+2]
+    if not (link.startswith('www.npmjs.com/') or link.startswith('registry.npmjs.org/')):
+        return ret, new_link
 
-            tar_name = f'{tar_name}-{oss_version}'
-            new_link = f'https://registry.npmjs.org/{oss_name_npm}/-/{tar_name}.tgz'
-            ret = True
-        except Exception as error:
-            ret = False
-            logger.warning('Cannot find the link for npm (url:'+link+') '+str(error))
+    # Type A: already a tarball URL (scoped/unscoped)
+    if '/-/' in link and link.rstrip('/').endswith('.tgz'):
+        return True, f'https://{link.lstrip("https://").lstrip("http://")}'
+
+    # Type B: package page URL — resolve via registry API
+    try:
+        oss_name_npm, oss_version = _parse_npm_package_link(link)
+        if not oss_name_npm:
+            return ret, new_link
+        if not oss_version and checkout_version:
+            oss_version = checkout_version.strip()
+
+        if oss_version:
+            api_url = f'https://registry.npmjs.org/{oss_name_npm}/{oss_version}'
+        else:
+            api_url = f'https://registry.npmjs.org/{oss_name_npm}'
+
+        npm_response = requests.get(api_url, timeout=5)
+        if npm_response.status_code == 200:
+            data = npm_response.json()
+            if oss_version:
+                tarball = data.get('dist', {}).get('tarball', '')
+            else:
+                latest_ver = data.get('dist-tags', {}).get('latest', '')
+                tarball = ''
+                if latest_ver:
+                    tarball = data.get('versions', {}).get(latest_ver, {}).get('dist', {}).get('tarball', '')
+            if tarball:
+                new_link = tarball
+                ret = True
+    except Exception as error:
+        ret = False
+        logger.warning('Cannot find the link for npm (url:'+link+') '+str(error))
+
     return ret, new_link
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving npm package links to published tarball URLs.
  * Supports both scoped and unscoped packages, with optional version selection.
  * Preserves existing tarball links.

* **Bug Fixes**
  * Added handling for invalid links, unavailable packages, and request failures with warnings.
  * Reports the resolved package version when applicable.

* **Test Results**

<h2>Test: fosslight_download npm URL return values</h2>
<p>Verified with 50 <code>https://registry.npmjs.org/</code> URLs using <code>fosslight_download</code>.</p>
<ul>
  <li><b>Without <code>-c</code></b>: 50/50 success</li>
  <li><b>With <code>-c</code> (version different from the link)</b>: 50/50 success</li>
</ul>
<p>Return fields: <code>success</code>, <code>oss_name</code>, <code>oss_version</code>, <code>clarified_version</code>, <code>link</code></p>
<h3>Without <code>-c</code></h3>
<table>
  <thead>
    <tr>
      <th>Input URL</th>
      <th>success</th>
      <th>oss_name</th>
      <th>oss_version</th>
      <th>clarified_version</th>
      <th>link</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>https://registry.npmjs.org/react/-/react-19.2.8.tgz</code></td>
      <td>true</td>
      <td><code>npm:react</code></td>
      <td><code>19.2.8</code></td>
      <td><code>19.2.8</code></td>
      <td><code>https://registry.npmjs.org/react/-/react-19.2.8.tgz</code></td>
    </tr>
    <tr>
      <td><code>https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz</code></td>
      <td>true</td>
      <td><code>npm:@nestjs/jwt</code></td>
      <td><code>11.0.2</code></td>
      <td><code>11.0.2</code></td>
      <td><code>https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz</code></td>
    </tr>
    <tr>
      <td><code>https://registry.npmjs.org/socket.io</code></td>
      <td>true</td>
      <td><code>npm:socket.io</code></td>
      <td><code>4.8.3</code></td>
      <td><code>4.8.3</code></td>
      <td><code>https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz</code></td>
    </tr>
    <tr>
      <td><code>https://registry.npmjs.org/@reduxjs/toolkit</code></td>
      <td>true</td>
      <td><code>npm:@reduxjs/toolkit</code></td>
      <td><code>2.12.0</code></td>
      <td><code>2.12.0</code></td>
      <td><code>https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz</code></td>
    </tr>
  </tbody>
</table>
<h3>With <code>-c</code> (version different from the link)</h3>
<table>
  <thead>
    <tr>
      <th>Input URL</th>
      <th><code>-c</code></th>
      <th>success</th>
      <th>oss_name</th>
      <th>oss_version</th>
      <th>clarified_version</th>
      <th>link</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><code>https://registry.npmjs.org/react/-/react-19.2.8.tgz</code></td>
      <td><code>19.0.8</code></td>
      <td>true</td>
      <td><code>npm:react</code></td>
      <td><code>19.2.8</code></td>
      <td><code>19.2.8</code></td>
      <td><code>https://registry.npmjs.org/react/-/react-19.2.8.tgz</code></td>
    </tr>
    <tr>
      <td><code>https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz</code></td>
      <td><code>11.0.1</code></td>
      <td>true</td>
      <td><code>npm:@nestjs/jwt</code></td>
      <td><code>11.0.2</code></td>
      <td><code>11.0.2</code></td>
      <td><code>https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz</code></td>
    </tr>
    <tr>
      <td><code>https://registry.npmjs.org/socket.io</code></td>
      <td><code>4.8.2</code></td>
      <td>true</td>
      <td><code>npm:socket.io</code></td>
      <td><code>4.8.2</code></td>
      <td><code>4.8.2</code></td>
      <td><code>https://registry.npmjs.org/socket.io/-/socket.io-4.8.2.tgz</code></td>
    </tr>
    <tr>
      <td><code>https://registry.npmjs.org/@reduxjs/toolkit</code></td>
      <td><code>2.11.2</code></td>
      <td>true</td>
      <td><code>npm:@reduxjs/toolkit</code></td>
      <td><code>2.11.2</code></td>
      <td><code>2.11.2</code></td>
      <td><code>https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz</code></td>
    </tr>
  </tbody>
</table>
<h3>Behavior</h3>
<table>
  <thead>
    <tr>
      <th>URL type</th>
      <th>Without <code>-c</code></th>
      <th>With <code>-c</code> (different version)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Tarball URL (<code>.../-/....tgz</code>)</td>
      <td>Keep tarball version</td>
      <td>Keep tarball version (<code>-c</code> ignored)</td>
    </tr>
    <tr>
      <td>Package name only (<code>registry.npmjs.org/&lt;pkg&gt;</code>)</td>
      <td>Resolve <b>latest</b></td>
      <td>Resolve <b><code>-c</code> version</b></td>
    </tr>
  </tbody>
</table>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->