### PR TITLE
Exclude __tests__ directories by default.

### DIFF
--- a/src/fosslight_util/exclude.py
+++ b/src/fosslight_util/exclude.py
@@ -7,7 +7,7 @@ import os
 import fnmatch
 from typing import List
 
-EXCLUDE_DIRECTORY = ["test", "tests", "doc", "docs", "intermediates"]
+EXCLUDE_DIRECTORY = ["test", "tests", "__tests__", "doc", "docs", "intermediates"]
 PACKAGE_DIRECTORY = ["node_modules", "venv", "Pods", "Carthage"]
 EXCLUDE_FILENAME = [
     "changelog", "config.guess", "config.sub", "changes", "ltmain.sh",


### PR DESCRIPTION
Align Jest-style test folders with existing test/tests exclusion in get_excluded_paths.